### PR TITLE
Add birational equivalence between Montgomery and Weierstrass curve families

### DIFF
--- a/Eduard/Cryptography/ECMath.cs
+++ b/Eduard/Cryptography/ECMath.cs
@@ -26,9 +26,6 @@ namespace Eduard.Cryptography
             if (right == ECPoint.POINT_INFINITY)
                 return left;
 
-            if (left == Negate(curve, right))
-                return ECPoint.POINT_INFINITY;
-
             BigInteger lambda = -1;
             BigInteger xDiff = 0;
             BigInteger yDiff = 0;
@@ -54,8 +51,11 @@ namespace Eduard.Cryptography
             {
                 xDiff = (3 * left.x) % curve.field;
                 xDiff = (xDiff * left.x) % curve.field;
+
                 xDiff = (xDiff + curve.a) % curve.field;
                 yDiff = (2 * left.y) % curve.field;
+
+                if (yDiff == 0) return ECPoint.POINT_INFINITY;
                 inv = yDiff.Inverse(curve.field);
                 lambda = (xDiff * inv) % curve.field;
             }

--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -12,6 +12,39 @@ namespace Eduard.Cryptography.Extensions
     public static class EllipticCurveExtensions
     {
         /// <summary>
+        /// Convert a Montgomery curve to the equivalent Weierstrass curve.
+        /// </summary>
+        /// <param name="curve"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static EllipticCurve ToWeierstrassCurve(this MontgomeryCurve curve)
+        {
+            if (curve.B == 0 || curve.A == 2 || curve.A == curve.field - 2 || (curve.cofactor & 0x3) != 0)
+                throw new ArgumentException("The Montgomery curve is invalid.");
+
+            BigInteger order = curve.order;
+            BigInteger cofactor = curve.cofactor;
+
+            BigInteger p = curve.field;
+            BigInteger A1 = (curve.A * curve.A) % p;
+
+            BigInteger A2 = (curve.A * A1) % p;
+            BigInteger A3 = (p + 3 - A1) % p;
+
+            BigInteger A4 = (p + ((2 * A2) % p) - ((9 * curve.A) % p)) % p;
+            BigInteger B1 = (curve.B * curve.B) % p;
+
+            BigInteger B2 = (B1 * curve.B) % p;
+            BigInteger B3 = ((27 * B2) % p).Inverse(p);
+
+            BigInteger B4 = (9 * curve.B) % p;
+            BigInteger a = (((A3 * B3) % p) * B4) % p;
+
+            BigInteger b = (A4 * B3) % p;
+            return new EllipticCurve(a, b, p, order, cofactor);
+        }
+
+        /// <summary>
         /// Convert a Montgomery curve to the equivalent twisted Edwards curve.
         /// </summary>
         /// <param name="curve"></param>

--- a/Eduard/Cryptography/MontyMath.cs
+++ b/Eduard/Cryptography/MontyMath.cs
@@ -29,14 +29,11 @@ namespace Eduard.Cryptography
             if (right == ECPoint.POINT_INFINITY)
                 return left;
 
-            if (left == Negate(curve, right))
-                return ECPoint.POINT_INFINITY;
-
             BigInteger lambda = -1;
             BigInteger xDiff = 0;
+
             BigInteger yDiff = 0;
             BigInteger inv = 0;
-
 
             if (left != right)
             {
@@ -62,6 +59,7 @@ namespace Eduard.Cryptography
                 yDiff = (curve.B * left.y) % curve.field;
                 yDiff = (2 * yDiff) % curve.field;
 
+                if (yDiff == 0) return ECPoint.POINT_INFINITY;
                 inv = yDiff.Inverse(curve.field);
                 lambda = (xDiff * inv) % curve.field;
             }


### PR DESCRIPTION
- Implements birational equivalence between Montgomery and Weierstrass curves.
- Enables mapping of points between these curve families for improved interoperability.