### PR TITLE
Add birational equivalence and point mapping between Weierstrass and Montgomery curves

### DIFF
--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -72,6 +72,70 @@ namespace Eduard.Cryptography.Extensions
         }
 
         /// <summary>
+        /// Convert an affine point on a Weierstrass curve to the corresponding affine point on the Montgomery curve.
+        /// </summary>
+        /// <param name="curve"></param>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
+        public static ECPoint ToMontgomeryPoint(this EllipticCurve curve, ECPoint point)
+        {
+            if ((curve.cofactor & 0x3) != 0)
+                throw new ArgumentException("The Weierstrass curve is invalid.");
+
+            Polynomial.SetField(curve.field);
+            BigInteger p = curve.field;
+
+            /* map the point at infinity on a Montgomery curve to its equivalent on the Weierstrass curve */
+            if (point == ECPoint.POINT_INFINITY) return ECPoint.POINT_INFINITY;
+
+            var roots = new List<BigInteger>();
+            Polynomial W = new Polynomial(1, 0, curve.a, curve.b);
+
+            /* find the roots of the polynomial associated with the Weierstrass curve */
+            W.FindRoots(ref roots);
+            Polynomial P = 1;
+
+            for (int i = 0; i < roots.Count; i++)
+            {
+                Polynomial Q = new Polynomial(1, p - roots[i]);
+                P *= Q;
+            }
+
+            W /= P;
+            BigInteger alpha = 0;
+            bool found = false;
+
+            Polynomial.Solve(W, ref roots);
+            BigInteger s = 0;
+
+            for (int i = 0; i < roots.Count; i++)
+            {
+                alpha = roots[i];
+                s = (((3 * ((alpha * alpha) % p)) % p) + curve.a) % p;
+
+                /* find the root corresponding to the x-coordinate of the 4-torsion point */
+                if (BigInteger.Jacobi(s, p) == 1)
+                {
+                    found = true;
+                    break;
+                }
+            }
+
+            /* if no 4-torsion point is found (x-coordinate is a root of the 4-division polynomial), the Weierstrass curve is likely not properly parameterized */
+            if (!found) throw new ArgumentException("Weierstrass curve cannot be converted to Montgomery form.");
+
+            s = curve.Sqrt(s).Inverse(p);
+            BigInteger Xp = point.GetAffineX();
+
+            BigInteger Yp = point.GetAffineY();
+            BigInteger X = (s * ((p + Xp - alpha) % p)) % p;
+
+            BigInteger Y = (s * Yp) % p;
+            return new ECPoint(X, Y);
+        }
+
+        /// <summary>
         /// Convert a Montgomery curve to the equivalent Weierstrass curve.
         /// </summary>
         /// <param name="curve"></param>

--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -43,6 +43,7 @@ namespace Eduard.Cryptography.Extensions
 
             W /= P;
             BigInteger alpha = 0;
+            bool found = false;
 
             Polynomial.Solve(W, ref roots);
             BigInteger s = 0;
@@ -53,8 +54,15 @@ namespace Eduard.Cryptography.Extensions
                 s = (((3 * ((alpha * alpha) % p)) % p) + curve.a) % p;
 
                 /* find the root corresponding to the x-coordinate of the 4-torsion point */
-                if (BigInteger.Jacobi(s, p) == 1) break;
+                if (BigInteger.Jacobi(s, p) == 1)
+                {
+                    found = true;
+                    break;
+                }
             }
+
+            if(!found)
+                throw new ArgumentException("Weierstrass curve cannot be converted to Montgomery form.");
 
             s = curve.Sqrt(s).Inverse(p);
             BigInteger A = (3 * alpha * s) % p;

--- a/Eduard/Cryptography/Polynomial.cs
+++ b/Eduard/Cryptography/Polynomial.cs
@@ -634,6 +634,13 @@ namespace Eduard.Cryptography
             Polynomial poly = Gcd(vtemp, self);
             if (poly == 1) return;
 
+            /* compute the roots of a polynomial early if the degree is 1 or 2 */
+            if (poly.Degree == 1 || poly.Degree == 2)
+            {
+                Solve(poly, ref roots);
+                return;
+            }
+
             if (poly.Degree >= 1 && poly != 0 && poly != this)
                 self = new Polynomial(poly);
 

--- a/Eduard/Cryptography/Polynomial.cs
+++ b/Eduard/Cryptography/Polynomial.cs
@@ -543,11 +543,11 @@ namespace Eduard.Cryptography
             {
                 BigInteger a = BigInteger.Next(rand, 1, field - 1);
                 Polynomial g = new Polynomial(1, a);
+                
                 Polynomial h = Pow(g, (field - 1) / 2, this);
                 Polynomial poly = h + 1;
 
-                if (poly.Degree == 0) continue;
-
+                if (poly == 1) continue;
                 Polynomial factor = Gcd(poly, this);
 
                 if (factor.Degree != 0)
@@ -584,11 +584,15 @@ namespace Eduard.Cryptography
                 ac4 = MulMod(ac4, poly.coeffs[0]);
                 BigInteger delta = AddMod(sb, ac4);
 
+                int jSymbol = BigInteger.Jacobi(delta, field);
+                if (jSymbol == -1) return -1;
+
                 BigInteger root = Sqrt(delta, true);
                 BigInteger val = MulMod(2, poly.coeffs[2]);
-                BigInteger inv = val.Inverse(field);
 
+                BigInteger inv = val.Inverse(field);
                 BigInteger t = AddMod(field - poly.coeffs[1], root);
+
                 t = MulMod(inv, t);
                 roots.Add(t);
 
@@ -628,9 +632,7 @@ namespace Eduard.Cryptography
             vtemp -= aux;
 
             Polynomial poly = Gcd(vtemp, self);
-
-            if (poly == 1)
-                return;
+            if (poly == 1) return;
 
             if (poly.Degree >= 1 && poly != 0 && poly != this)
                 self = new Polynomial(poly);


### PR DESCRIPTION
Implement the birational equivalence between Weierstrass and Montgomery curve families,
and add the mapping of affine points between these curves.