### PR TITLE
Add birational equivalence and affine point mapping between Weierstrass and twisted Edwards curves

### DIFF
--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -260,12 +260,11 @@ namespace Eduard.Cryptography.Extensions
             BigInteger Xm = (s * ((p + Xp - alpha) % p)) % p;
 
             BigInteger Ym = (s * Yp) % p;
-            BigInteger B_root = curve.Sqrt(s);
-
             BigInteger y_inv = Ym.Inverse(p);
-            BigInteger x1_inv = ((Xm + 1) % p).Inverse(p);
 
-            BigInteger X = (((B_root * Xm) % p) * y_inv) % p;
+            BigInteger x1_inv = ((Xm + 1) % p).Inverse(p);
+            BigInteger X = (Xm * y_inv) % p;
+
             BigInteger Y = ((p + Xm - 1) * x1_inv) % p;
             return new ECPoint(X, Y);
         }
@@ -473,7 +472,7 @@ namespace Eduard.Cryptography.Extensions
             BigInteger y_inv = Yp.Inverse(p);
             BigInteger x1_inv = ((Xp + 1) % p).Inverse(p);
 
-            BigInteger X = (((B_root * Xp) % p) * y_inv) % p;
+            BigInteger X = (Xp * y_inv) % p;
             BigInteger Y = ((p + Xp - 1) * x1_inv) % p;
             return new ECPoint(X, Y);
         }


### PR DESCRIPTION
This pull request adds support for the birational equivalence between the Weierstrass and twisted Edwards curve families. 
The implementation includes both the mathematical transformations for the curves themselves and the mapping of affine 
points between these families.