### PR TITLE
Add protection against invalid and twisted points in scalar multiplication

### DIFF
--- a/Eduard/Cryptography/ECMath.cs
+++ b/Eduard/Cryptography/ECMath.cs
@@ -90,14 +90,14 @@ namespace Eduard.Cryptography
         /// <param name="point"></param>
         /// <param name="opMode"></param>
         /// <returns></returns>
-        public static ECPoint Multiply(EllipticCurve curve, BigInteger k, ECPoint point, ECMode opMode = ECMode.EC_STANDARD_AFFINE)
+        public static ECPoint Multiply(EllipticCurve curve, BigInteger k, ECPoint point, ECMode opMode = ECMode.EC_STANDARD_AFFINE, bool securityCheck = false)
         {
             if (k < 0) throw new ArgumentException("Bad input.");
 
             if (k == 0 || point == ECPoint.POINT_INFINITY)
                 return ECPoint.POINT_INFINITY;
 
-            if (!curve.ValidatePoint(point))
+            if (!curve.ValidatePoint(point) && securityCheck)
                 throw new ArgumentException("Generator point creates a small-order subgroup on the Weierstrass curve.");
 
             ECPoint temp = point;

--- a/Eduard/Cryptography/Extensions/SafeCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/SafeCurveExtensions.cs
@@ -10,10 +10,26 @@ namespace Eduard.Cryptography.Extensions
     {
         internal static bool ValidatePoint(this EllipticCurve curve, ECPoint point)
         {
+            var Y2 = curve.Evaluate(point.GetAffineX());
+            int jSymbol = BigInteger.Jacobi(Y2, curve.field);
+
+            /* check if y-coordinate is defined */
+            if (jSymbol != 1 && Y2 > 0)
+                return false;
+            else
+            {
+                BigInteger y = point.GetAffineY();
+                BigInteger Yp2 = (y * y) % curve.field;
+
+                /* point not on this Weierstrass curve; likely on the twist */
+                if (Yp2 != Y2) return false;
+            }
+
             ECPoint result = ECPoint.POINT_INFINITY;
             int t = curve.cofactor.GetBits();
             BigInteger k = curve.cofactor;
 
+            /* check if the point generates a small-order subgroup */
             JacobianPoint auxPoint = JacobianPoint.POINT_INFINITY;
             var basePoint = curve.ToModifiedJacobian(point);
 


### PR DESCRIPTION
Updates scalar multiplication to include an optional parameter for point validation, providing resistance against attacks 
using invalid points or points on the twisted Weierstrass curve, while allowing flexibility for cryptographic requirements.