### PR TITLE
Fix parameterization of Montgomery and twisted Edwards curves equivalent to twisted Weierstrass curves

### DIFF
--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -188,10 +188,10 @@ namespace Eduard.Cryptography.Extensions
             if (!found)
                 throw new ArgumentException("Weierstrass curve cannot be converted to twisted Edwards form.");
 
-            s = curve.Sqrt(s).Inverse(p);
-            BigInteger A = (3 * alpha * s) % p;
+            BigInteger t = curve.Sqrt(s, true).Inverse(p);
+            BigInteger A = (3 * alpha * t) % p;
 
-            BigInteger B = s;
+            BigInteger B = t;
             BigInteger B_inv = B.Inverse(p);
 
             BigInteger a = ((A + 2) * B_inv) % p;

--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -125,13 +125,13 @@ namespace Eduard.Cryptography.Extensions
             /* if no 4-torsion point is found (x-coordinate is a root of the 4-division polynomial), the Weierstrass curve is likely not properly parameterized */
             if (!found) throw new ArgumentException("Weierstrass curve cannot be converted to Montgomery form.");
 
-            s = curve.Sqrt(s).Inverse(p);
+            BigInteger ts = curve.Sqrt(s, true).Inverse(p);
             BigInteger Xp = point.GetAffineX();
 
             BigInteger Yp = point.GetAffineY();
-            BigInteger X = (s * ((p + Xp - alpha) % p)) % p;
+            BigInteger X = (ts * ((p + Xp - alpha) % p)) % p;
 
-            BigInteger Y = (s * Yp) % p;
+            BigInteger Y = (ts * Yp) % p;
             return new ECPoint(X, Y);
         }
 

--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -64,10 +64,10 @@ namespace Eduard.Cryptography.Extensions
             if(!found)
                 throw new ArgumentException("Weierstrass curve cannot be converted to Montgomery form.");
 
-            s = curve.Sqrt(s).Inverse(p);
-            BigInteger A = (3 * alpha * s) % p;
+            BigInteger t = curve.Sqrt(s, true).Inverse(p);
+            BigInteger A = (3 * alpha * t) % p;
 
-            BigInteger B = s;
+            BigInteger B = t;
             return new MontgomeryCurve(A, B, p, order, cofactor);
         }
 

--- a/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Cryptography/Extensions/EllipticCurveExtensions.cs
@@ -253,13 +253,13 @@ namespace Eduard.Cryptography.Extensions
             /* if no 4-torsion point is found (x-coordinate is a root of the 4-division polynomial), the Weierstrass curve is likely not properly parameterized */
             if (!found) throw new ArgumentException("Weierstrass curve cannot be converted to twisted Edwards form.");
 
-            s = curve.Sqrt(s).Inverse(p);
+            BigInteger ts = curve.Sqrt(s, true).Inverse(p);
             BigInteger Xp = point.GetAffineX();
 
             BigInteger Yp = point.GetAffineY();
-            BigInteger Xm = (s * ((p + Xp - alpha) % p)) % p;
+            BigInteger Xm = (ts * ((p + Xp - alpha) % p)) % p;
 
-            BigInteger Ym = (s * Yp) % p;
+            BigInteger Ym = (ts * Yp) % p;
             BigInteger y_inv = Ym.Inverse(p);
 
             BigInteger x1_inv = ((Xm + 1) % p).Inverse(p);


### PR DESCRIPTION
This pull request corrects the parameterization of the Montgomery and twisted Edwards curves derived from twisted Weierstrass curves. The update ensures consistency of the transformations and the validity of the resulting curve models under birational equivalence. This refinement strengthens the correctness of subsequent point mappings and curve-based operations.