### PR TITLE
Add functions for generator point retrieval and base point setting

### DIFF
--- a/Eduard/Cryptography/EllipticCurve.cs
+++ b/Eduard/Cryptography/EllipticCurve.cs
@@ -201,6 +201,34 @@ namespace Eduard.Cryptography
         }
 
         /// <summary>
+        /// Sets the specified base point on the elliptic curve.
+        /// </summary>
+        /// <param name="point">The affine point to set as the generator.</param>
+        public void SetBasePoint(ECPoint point)
+        {
+            ECPoint tempPoint = point;
+            var Y2 = Evaluate(tempPoint.GetAffineX());
+
+            if (BigInteger.Jacobi(Y2, field) != 1 && Y2 > 0)
+                throw new Exception("The generator point is not on the Weierstrass curve.");
+            else
+            {
+                BigInteger y = tempPoint.GetAffineY();
+                BigInteger eval = (y * y) % field;
+
+                if (eval != Y2)
+                    throw new Exception("Invalid generator point for Weierstrass curve.");
+                else
+                {
+                    ECPoint testPoint = ECMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
+                    if (testPoint != ECPoint.POINT_INFINITY) basePoint = tempPoint;
+                    else
+                        throw new Exception("Chosen generator point yields small-order subgroup on Weierstrass curve.");
+                }
+            }
+        }
+
+        /// <summary>
         /// Computes the modular square root of an integer over the prime field.
         /// </summary>
         /// <param name="val"></param>

--- a/Eduard/Cryptography/EllipticCurve.cs
+++ b/Eduard/Cryptography/EllipticCurve.cs
@@ -156,69 +156,48 @@ namespace Eduard.Cryptography
         }
 
         /// <summary>
-        /// Get a random base point or set a specified base point on the elliptic curve.
+        /// Generates a random base point on the elliptic curve.
         /// </summary>
-        public ECPoint BasePoint
+        /// <param name="genPoint">Specifies whether the base point on the elliptic curve should be generated conditionally.</param>
+        /// <returns></returns>
+        public ECPoint GetBasePoint(bool genPoint = false)
         {
-            get
-            {
-                bool done = false;
-                BigInteger x = 0;
+            bool done = false;
+            BigInteger x = 0;
 
-                BigInteger y = 0;
-                BigInteger temp = 0;
+            BigInteger y = 0;
+            BigInteger temp = 0;
 
-                do
-                {
-                    x = BigInteger.Next(rand, 0, field - 1);
-                    temp = Evaluate(x);
-                    
-                    if (temp < 2)
-                        return new ECPoint(x, temp);
-
-                    if (BigInteger.Jacobi(temp, field) == 1)
-                    {
-                        done = true;
-                        y = Sqrt(temp);
-                        
-                        BigInteger eval = (y * y) % field;
-                        if (temp != eval) done = false;
-
-                        if(done)
-                        {
-                            ECPoint tempPoint = new ECPoint(x, y);
-                            basePoint = ECMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
-                            done = (basePoint != ECPoint.POINT_INFINITY);
-                        }
-                    }
-                }
-                while (!done);
-
+            if(genPoint && basePoint != ECPoint.POINT_INFINITY)
                 return basePoint;
-            }
-            set
+
+            do
             {
-                ECPoint tempPoint = value;
-                var Y2 = Evaluate(tempPoint.GetAffineX());
+                x = BigInteger.Next(rand, 0, field - 1);
+                temp = Evaluate(x);
 
-                if (BigInteger.Jacobi(Y2, field) != 1 && Y2 > 0)
-                    throw new Exception("The generator point is not on the Weierstrass curve.");
-                else
+                if (temp < 2)
+                    return new ECPoint(x, temp);
+
+                if (BigInteger.Jacobi(temp, field) == 1)
                 {
-                    BigInteger y = tempPoint.GetAffineY();
-                    BigInteger eval = (y * y) % field;
+                    done = true;
+                    y = Sqrt(temp);
 
-                    if (eval != Y2)
-                        throw new Exception("Invalid generator point for Weierstrass curve.");
-                    else
+                    BigInteger eval = (y * y) % field;
+                    if (temp != eval) done = false;
+
+                    if (done)
                     {
-                        ECPoint point = ECMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
-                        if (point != ECPoint.POINT_INFINITY) basePoint = tempPoint;
-                        else
-                            throw new Exception("Chosen generator point yields small-order subgroup on Weierstrass curve.");
+                        ECPoint tempPoint = new ECPoint(x, y);
+                        basePoint = ECMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
+                        done = (basePoint != ECPoint.POINT_INFINITY);
                     }
                 }
             }
+            while (!done);
+
+            return basePoint;
         }
 
         /// <summary>

--- a/Eduard/Cryptography/EllipticCurve.cs
+++ b/Eduard/Cryptography/EllipticCurve.cs
@@ -158,9 +158,9 @@ namespace Eduard.Cryptography
         /// <summary>
         /// Generates a random base point on the elliptic curve.
         /// </summary>
-        /// <param name="genPoint">Specifies whether the base point on the elliptic curve should be generated conditionally.</param>
+        /// <param name="isGenerated">Specifies whether the base point on the elliptic curve should be generated conditionally.</param>
         /// <returns></returns>
-        public ECPoint GetBasePoint(bool genPoint = false)
+        public ECPoint GetBasePoint(bool isGenerated = false)
         {
             bool done = false;
             BigInteger x = 0;
@@ -168,7 +168,7 @@ namespace Eduard.Cryptography
             BigInteger y = 0;
             BigInteger temp = 0;
 
-            if(genPoint && basePoint != ECPoint.POINT_INFINITY)
+            if(isGenerated && basePoint != ECPoint.POINT_INFINITY)
                 return basePoint;
 
             do

--- a/Eduard/Cryptography/TwistedEdwardsCurve.cs
+++ b/Eduard/Cryptography/TwistedEdwardsCurve.cs
@@ -131,6 +131,34 @@ namespace Eduard.Cryptography
         }
 
         /// <summary>
+        /// Sets the specified base point on the twisted Edwards curve.
+        /// </summary>
+        /// <param name="point">The affine point to set as the generator.</param>
+        public void SetBasePoint(ECPoint point)
+        {
+            ECPoint tempPoint = point;
+            var temp = Evaluate(tempPoint.GetAffineY());
+
+            if (BigInteger.Jacobi(temp, field) != 1 && temp > 0)
+                throw new Exception("The generator point is not on the twisted Edwards curve.");
+            else
+            {
+                BigInteger x = tempPoint.GetAffineX();
+                BigInteger eval = (x * x) % field;
+
+                if (eval != temp)
+                    throw new Exception("Invalid generator point for the twisted Edwards curve.");
+                else
+                {
+                    ECPoint testPoint = TwistedEdwardsMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
+                    if (testPoint != ECPoint.POINT_INFINITY) basePoint = tempPoint;
+                    else
+                        throw new Exception("Chosen generator point yields a small-order subgroup on the twisted Edwards curve.");
+                }
+            }
+        }
+
+        /// <summary>
         /// Computes the modular square root of an integer over the prime field.
         /// </summary>
         /// <param name="val"></param>

--- a/Eduard/Cryptography/TwistedEdwardsCurve.cs
+++ b/Eduard/Cryptography/TwistedEdwardsCurve.cs
@@ -86,69 +86,48 @@ namespace Eduard.Cryptography
         }
 
         /// <summary>
-        /// Get a random base point or set a specified base point on the elliptic curve.
+        /// Generates a random base point on the twisted Edwards curve.
         /// </summary>
-        public ECPoint BasePoint
+        /// <param name="isGenerated">Specifies whether the base point on the twisted Edwards curve should be generated conditionally.</param>
+        /// <returns></returns>
+        public ECPoint GetBasePoint(bool isGenerated = false)
         {
-            get
-            {
-                bool done = false;
-                BigInteger x = 0;
+            bool done = false;
+            BigInteger x = 0;
 
-                BigInteger y = 0;
-                BigInteger temp = 0;
+            BigInteger y = 0;
+            BigInteger temp = 0;
 
-                do
-                {
-                    y = BigInteger.Next(rand, 0, field - 1);
-                    temp = Evaluate(y);
-
-                    if (temp < 2)
-                        return new ECPoint(temp, y);
-
-                    if (BigInteger.Jacobi(temp, field) == 1)
-                    {
-                        done = true;
-                        x = Sqrt(temp);
-
-                        BigInteger eval = (x * x) % field;
-                        if (temp != eval) done = false;
-
-                        if (done)
-                        {
-                            ECPoint tempPoint = new ECPoint(x, y);
-                            basePoint = TwistedEdwardsMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
-                            done = (basePoint != ECPoint.POINT_INFINITY);
-                        }
-                    }
-                }
-                while (!done);
-
+            if (isGenerated && basePoint != ECPoint.POINT_INFINITY)
                 return basePoint;
-            }
-            set
+
+            do
             {
-                ECPoint tempPoint = value;
-                var temp = Evaluate(tempPoint.GetAffineY());
+                y = BigInteger.Next(rand, 0, field - 1);
+                temp = Evaluate(y);
 
-                if (BigInteger.Jacobi(temp, field) != 1 && temp > 0)
-                    throw new Exception("The generator point is not on the twisted Edwards curve.");
-                else
+                if (temp < 2)
+                    return new ECPoint(temp, y);
+
+                if (BigInteger.Jacobi(temp, field) == 1)
                 {
-                    BigInteger x = tempPoint.GetAffineX();
-                    BigInteger eval = (x * x) % field;
+                    done = true;
+                    x = Sqrt(temp);
 
-                    if (eval != temp)
-                        throw new Exception("Invalid generator point for the twisted Edwards curve.");
-                    else
+                    BigInteger eval = (x * x) % field;
+                    if (temp != eval) done = false;
+
+                    if (done)
                     {
-                        ECPoint point = TwistedEdwardsMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
-                        if (point != ECPoint.POINT_INFINITY) basePoint = tempPoint;
-                        else
-                            throw new Exception("Chosen generator point yields a small-order subgroup on the twisted Edwards curve.");
+                        ECPoint tempPoint = new ECPoint(x, y);
+                        basePoint = TwistedEdwardsMath.Multiply(this, cofactor, tempPoint, ECMode.EC_STANDARD_PROJECTIVE);
+                        done = (basePoint != ECPoint.POINT_INFINITY);
                     }
                 }
             }
+            while (!done);
+
+            return basePoint;
         }
 
         /// <summary>


### PR DESCRIPTION
Introduce a function for conditional retrieval of the generator point from an elliptic curve and a procedure to set the base point. These additions streamline the handling of generator points in cryptographic systems and digital signature schemes based on Weierstrass and twisted Edwards curves, ensuring correctness and security in curve operations.