### PR TITLE
Enhance curve arithmetic: batch addition, point representation, and comprehensive test coverage

### DIFF
--- a/BenchTests/Core/Poly/ModBenchmark.cs
+++ b/BenchTests/Core/Poly/ModBenchmark.cs
@@ -28,7 +28,7 @@ namespace Eduard.BenchTests.Poly
             int maxDegree = 2 * (degree - 1);
             left = new Polynomial(maxDegree);
 
-            for (int i = 0; i <= left.degree; i++)
+            for (int i = 0; i <= left.Degree; i++)
                 left.coeffs[i] = SecureRandom.Range(1, field - 1);
 
             PerfTuner.SetThreshold(PerfEntry.POLY_FFT_MOD, degree);

--- a/Eduard/BarrettReducer.cs
+++ b/Eduard/BarrettReducer.cs
@@ -185,6 +185,7 @@ namespace Eduard
         /// <param name="val">The value to reduce.</param>
         /// <param name="normalize">When true, performs full modular reduction via division.</param>
         /// <returns>val mod field in range [0, field-1].</returns>
+        /// <exception cref="InvalidOperationException">Thrown when modulus not initialized.</exception>
         /// <remarks>
         /// When normalize is set, uses direct division to handle arbitrary inputs including negatives.<br/>
         /// Otherwise, applies Barrett reduction assuming the input is already nearly reduced.

--- a/Eduard/BarrettReducer.cs
+++ b/Eduard/BarrettReducer.cs
@@ -180,6 +180,45 @@ namespace Eduard
         }
 
         /// <summary>
+        /// Computes modular inverses for all elements in a single batch.
+        /// </summary>
+        /// <param name="b">Values to invert.</param>
+        /// <returns>Array c where c[i] * b[i] = 1 (mod field).</returns>
+        /// <exception cref="InvalidOperationException">Thrown when modulus not initialized.</exception>
+        /// <remarks>
+        /// Uses Montgomery's simultaneous inversion trick. Computes a single inverse and <br/>
+        /// derives all others through multiplications. Assumes all elements are non-zero <br/>
+        /// and already reduced in [0, field-1].
+        /// </remarks>
+        internal static BigInteger[] InvMod(BigInteger[] b)
+        {
+            int n = b.Length;
+            BigInteger[] bp = new BigInteger[n];
+            BigInteger[] c = new BigInteger[n];
+
+            bp[0] = b[0];
+            int j, k;
+
+            for (j = 1; j < n; j++)
+            {
+                BigInteger currentVal = b[j];
+                bp[j] = MultMod(bp[j - 1], currentVal);
+            }
+
+            BigInteger fullN = InvMod(bp[n - 1]);
+
+            for (k = n - 1; k > 0; k--)
+            {
+                BigInteger currentVal = b[k];
+                c[k] = MultMod(fullN, bp[k - 1]);
+                fullN = MultMod(fullN, currentVal);
+            }
+
+            c[0] = fullN;
+            return c;
+        }
+
+        /// <summary>
         /// Reduces a value modulo the cached field using Barrett's algorithm.
         /// </summary>
         /// <param name="val">The value to reduce.</param>

--- a/Eduard/BarrettReducer.cs
+++ b/Eduard/BarrettReducer.cs
@@ -156,6 +156,30 @@ namespace Eduard
         }
 
         /// <summary>
+        /// Computes the dot product of two vectors modulo the cached field.
+        /// </summary>
+        /// <param name="x">First vector of field elements.</param>
+        /// <param name="y">Second vector of field elements.</param>
+        /// <returns>The sum of element-wise products reduced modulo field.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when modulus not initialized.</exception>
+        /// <remarks>
+        /// Assumes both vectors have the same length and all elements are already reduced in [0, field-1].
+        /// </remarks>
+        internal static BigInteger DotMult(BigInteger[] x, BigInteger[] y)
+        {
+            BigInteger res = 0;
+            int i, n = x.Length;
+
+            for (i = 0; i < n; i++)
+            {
+                BigInteger temp = MultMod(x[i], y[i]);
+                res = AddMod(res, temp);
+            }
+
+            return res;
+        }
+
+        /// <summary>
         /// Reduces a value modulo the cached field using Barrett's algorithm.
         /// </summary>
         /// <param name="val">The value to reduce.</param>

--- a/Eduard/FFT.cs
+++ b/Eduard/FFT.cs
@@ -215,8 +215,6 @@ namespace Eduard
                 return false;
 
             int degG = G.Length - 1;
-            BigInteger field = BarrettReducer.GetModulus();
-
             uint[] residues;
             pc = count;
 
@@ -306,11 +304,9 @@ namespace Eduard
                 for (i = 0; i < pc; i++)
                     residues[i] = t[i][j];
 
-                R[j] = garner.GetInteger(residues);
-                BigInteger diff = (G[j] - R[j]) % field;
-
-                if (diff < 0) diff += field;
-                R[j] = diff;
+                BigInteger remCoeff = garner.GetInteger(residues);
+                BigInteger redCoeff = BarrettReducer.Reduce(remCoeff);
+                R[j] = BarrettReducer.SubMod(G[j], redCoeff);
             }
 
             return true;

--- a/Eduard/Security/Curves/ECMath.cs
+++ b/Eduard/Security/Curves/ECMath.cs
@@ -85,12 +85,13 @@ namespace Eduard.Security.Curves
         /// Thrown when either array is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// Thrown when either array is empty or arrays have different lengths.
+        /// Thrown when the two arrays have different lengths.
         /// </exception>
         /// <remarks>
         /// Uses Montgomery's simultaneous inversion to batch all modular inverses into a <br/>
         /// single inversion plus 3(n-1) multiplications. Handles point at infinity, doubling, <br/>
-        /// and vertical line cases for each pair independently.
+        /// and vertical line cases for each pair independently. If both arrays are empty, the <br/>
+        /// method returns immediately without performing any arithmetic.
         /// </remarks>
         public static void Add(EllipticCurve curve, ECPoint[] left, ECPoint[] right)
         {
@@ -100,27 +101,22 @@ namespace Eduard.Security.Curves
             if (ReferenceEquals(null, right))
                 throw new ArgumentNullException(nameof(right));
 
-            int n = left.Length, k;
+            int n = left.Length;
             int rn = right.Length;
-            var skip = new byte[n];
-
-            if (n == 0)
-                throw new ArgumentException(
-                    "Point array cannot be empty.",
-                    nameof(left));
-
-            if (rn == 0)
-                throw new ArgumentException(
-                    "Point array cannot be empty.",
-                    nameof(right));
 
             if (n != rn)
                 throw new ArgumentException(
                     "Point arrays must have the same length.",
                     nameof(right));
 
+            if (n == 0)
+                return;
+
             BigInteger[] A = new BigInteger[n];
             BigInteger[] B = new BigInteger[n];
+
+            var skip = new byte[n];
+            int k;
 
             for(k = 0; k < n; k++)
             {

--- a/Eduard/Security/Curves/ECMath.cs
+++ b/Eduard/Security/Curves/ECMath.cs
@@ -42,7 +42,6 @@ namespace Eduard.Security.Curves
             BigInteger yDiff = 0;
             BigInteger inv = 0;
 
-
             if (left != right)
             {
                 xDiff = BarrettReducer.SubMod(right.x, left.x);
@@ -74,6 +73,101 @@ namespace Eduard.Security.Curves
             y = BarrettReducer.MultMod(y, lambda);
             y = BarrettReducer.SubMod(y, left.y);
             return new ECPoint(x, y);
+        }
+
+        public static void Add(EllipticCurve curve, ECPoint[] left, ECPoint[] right)
+        {
+            int n = left.Length, k;
+            var skip = new byte[n];
+
+            BigInteger[] A = new BigInteger[n];
+            BigInteger[] B = new BigInteger[n];
+
+            for(k = 0; k < n; k++)
+            {
+                if (left[k] == right[k])
+                {
+                    if (!left[k].isOnCurve)
+                    {
+                        skip[k] = 1;
+                        B[k] = 1;
+                        continue;
+                    }
+
+                    BigInteger lx = left[k].x;
+                    BigInteger ly = left[k].y;
+
+                    BigInteger x2 = BarrettReducer.MultMod(lx, lx);
+                    x2 = BarrettReducer.MultMod(3, x2);
+
+                    A[k] = BarrettReducer.AddMod(x2, curve.a);
+                    B[k] = BarrettReducer.AddMod(ly, ly);
+                }
+                else
+                {
+                    if (!left[k].isOnCurve)
+                    {
+                        skip[k] = 2;
+                        B[k] = 1;
+                        continue;
+                    }
+
+                    if (!right[k].isOnCurve)
+                    {
+                        skip[k] = 3;
+                        B[k] = 1;
+                        continue;
+                    }
+
+                    B[k] = BarrettReducer.SubMod(
+                        right[k].x, left[k].x);
+
+                    if (B[k] == 0)
+                    {
+                        skip[k] = 1;
+                        B[k] = 1;
+                        continue;
+                    }
+
+                    A[k] = BarrettReducer.SubMod(
+                        right[k].y, left[k].y);
+                }
+            }
+
+            /* apply Montgomery trick for fast inversion */
+            BigInteger[] C = BarrettReducer.InvMod(B);
+
+            for (k = 0; k < n; k++)
+            {
+                if (skip[k] == 1)
+                {
+                    right[k] = ECPoint.POINT_INFINITY;
+                    continue;
+                }
+
+                if (skip[k] == 2)
+                    continue;
+
+                if (skip[k] == 3)
+                {
+                    BigInteger lx = left[k].x;
+                    BigInteger ly = left[k].y;
+                    right[k] = new ECPoint(lx, ly);
+                    continue;
+                }
+
+                BigInteger m = BarrettReducer.MultMod(A[k], C[k]);
+                BigInteger m2 = BarrettReducer.MultMod(m, m);
+
+                BigInteger dx = BarrettReducer.AddMod(left[k].x, right[k].x);
+                BigInteger x = BarrettReducer.SubMod(m2, dx);
+
+                BigInteger y = BarrettReducer.SubMod(left[k].x, x);
+                y = BarrettReducer.MultMod(y, m);
+
+                y = BarrettReducer.SubMod(y, left[k].y);
+                right[k] = new ECPoint(x, y);
+            }
         }
 
         /// <summary>

--- a/Eduard/Security/Curves/ECMath.cs
+++ b/Eduard/Security/Curves/ECMath.cs
@@ -31,10 +31,10 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Add(EllipticCurve curve, ECPoint left, ECPoint right)
         {
-            if (left == ECPoint.POINT_INFINITY)
+            if (!left.isOnCurve)
                 return right;
 
-            if (right == ECPoint.POINT_INFINITY)
+            if (!right.isOnCurve)
                 return left;
 
             BigInteger lambda = -1;
@@ -238,7 +238,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Multiply(EllipticCurve curve, BigInteger k, ECPoint point, ECMode opMode = ECMode.EC_STANDARD_AFFINE, bool securityCheck = false)
         {
-            if (k == 0 || point == ECPoint.POINT_INFINITY)
+            if (k == 0 || !point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             string[] pointErrors = new string[]
@@ -398,7 +398,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Negate(EllipticCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             return new ECPoint(point.x, curve.field - point.y);

--- a/Eduard/Security/Curves/ECMath.cs
+++ b/Eduard/Security/Curves/ECMath.cs
@@ -75,6 +75,23 @@ namespace Eduard.Security.Curves
             return new ECPoint(x, y);
         }
 
+        /// <summary>
+        /// Adds two arrays of affine points pairwise on the Weierstrass elliptic curve.
+        /// </summary>
+        /// <param name="curve">The elliptic curve context containing field parameters.</param>
+        /// <param name="left">First array of points to add.</param>
+        /// <param name="right">Second array of points to add. Receives the results in-place.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when either array is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when either array is empty or arrays have different lengths.
+        /// </exception>
+        /// <remarks>
+        /// Uses Montgomery's simultaneous inversion to batch all modular inverses into a <br/>
+        /// single inversion plus 3(n-1) multiplications. Handles point at infinity, doubling, <br/>
+        /// and vertical line cases for each pair independently.
+        /// </remarks>
         public static void Add(EllipticCurve curve, ECPoint[] left, ECPoint[] right)
         {
             if (ReferenceEquals(left, null))

--- a/Eduard/Security/Curves/ECMath.cs
+++ b/Eduard/Security/Curves/ECMath.cs
@@ -77,8 +77,30 @@ namespace Eduard.Security.Curves
 
         public static void Add(EllipticCurve curve, ECPoint[] left, ECPoint[] right)
         {
+            if (ReferenceEquals(left, null))
+                throw new ArgumentNullException(nameof(left));
+
+            if (ReferenceEquals(null, right))
+                throw new ArgumentNullException(nameof(right));
+
             int n = left.Length, k;
+            int rn = right.Length;
             var skip = new byte[n];
+
+            if (n == 0)
+                throw new ArgumentException(
+                    "Point array cannot be empty.",
+                    nameof(left));
+
+            if (rn == 0)
+                throw new ArgumentException(
+                    "Point array cannot be empty.",
+                    nameof(right));
+
+            if (n != rn)
+                throw new ArgumentException(
+                    "Point arrays must have the same length.",
+                    nameof(right));
 
             BigInteger[] A = new BigInteger[n];
             BigInteger[] B = new BigInteger[n];

--- a/Eduard/Security/Curves/Ed3Math.cs
+++ b/Eduard/Security/Curves/Ed3Math.cs
@@ -48,8 +48,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint3 UnifiedAdd(TwistedEdwardsCurve curve, ECPoint3 left, ECPoint3 right)
         {
-            if (left == ECPoint3.POINT_INFINITY) return right;
-            if (right == ECPoint3.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
             BigInteger A1 = BarrettReducer.MultMod(left.z, right.z);
 
             BigInteger A2 = BarrettReducer.MultMod(A1, A1);
@@ -95,7 +95,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint3 UnifiedDoubling(TwistedEdwardsCurve curve, ECPoint3 point)
         {
-            if (point == ECPoint3.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint3.POINT_INFINITY;
 
             BigInteger B1 = BarrettReducer.AddMod(point.x, point.y);
@@ -136,7 +136,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint3 Negate(TwistedEdwardsCurve curve, ECPoint3 point)
         {
-            if(point == ECPoint3.POINT_INFINITY) 
+            if(!point.isOnCurve) 
                 return ECPoint3.POINT_INFINITY;
 
             BigInteger x = curve.field - point.x;

--- a/Eduard/Security/Curves/Ed4Math.cs
+++ b/Eduard/Security/Curves/Ed4Math.cs
@@ -44,8 +44,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 Add(TwistedEdwardsCurve curve, ECPoint4 left, ECPoint4 right)
         {
-            if (left == ECPoint4.POINT_INFINITY) return right;
-            if (right == ECPoint4.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
             if (left == Negate(curve, right))
                 return ECPoint4.POINT_INFINITY;
@@ -74,10 +74,10 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 UnifiedAdd(TwistedEdwardsCurve curve, ECPoint4 left, ECPoint4 right)
         {
-            if (left == ECPoint4.POINT_INFINITY) return right;
-            if (right == ECPoint4.POINT_INFINITY) return left;
-            BigInteger A1 = BarrettReducer.MultMod(left.x, right.x);
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
+            BigInteger A1 = BarrettReducer.MultMod(left.x, right.x);
             BigInteger A2 = BarrettReducer.MultMod(left.y, right.y);
             BigInteger B1t = BarrettReducer.MultMod(left.t, right.t);
 
@@ -120,8 +120,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 TwistUnifiedAdd(TwistedEdwardsCurve curve, ECPoint4 left, ECPoint4 right)
         {
-            if (left == ECPoint4.POINT_INFINITY) return right;
-            if (right == ECPoint4.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
             BigInteger B1 = BarrettReducer.SubMod(left.y, left.x);
             BigInteger B2 = BarrettReducer.SubMod(right.y, right.x);
@@ -167,10 +167,10 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 DedicatedAdd(TwistedEdwardsCurve curve, ECPoint4 left, ECPoint4 right)
         {
-            if (left == ECPoint4.POINT_INFINITY) return right;
-            if (right == ECPoint4.POINT_INFINITY) return left;
-            BigInteger A1 = BarrettReducer.MultMod(left.x, right.x);
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
+            BigInteger A1 = BarrettReducer.MultMod(left.x, right.x);
             BigInteger A2 = BarrettReducer.MultMod(left.y, right.y);
             BigInteger A3 = BarrettReducer.MultMod(left.z, right.t);
 
@@ -212,8 +212,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 TwistDedicatedAdd(TwistedEdwardsCurve curve, ECPoint4 left, ECPoint4 right)
         {
-            if (left == ECPoint4.POINT_INFINITY) return right;
-            if (right == ECPoint4.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
             BigInteger B1 = BarrettReducer.SubMod(left.y, left.x);
             BigInteger B2 = BarrettReducer.AddMod(right.y, right.x);
@@ -258,7 +258,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 DedicatedDoubling(TwistedEdwardsCurve curve, ECPoint4 point)
         {
-            if (point == ECPoint4.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint4.POINT_INFINITY;
 
             BigInteger A1 = BarrettReducer.MultMod(point.x, point.x);
@@ -302,7 +302,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4 Negate(TwistedEdwardsCurve curve, ECPoint4 point)
         {
-            if(point == ECPoint4.POINT_INFINITY) 
+            if(!point.isOnCurve) 
                 return ECPoint4.POINT_INFINITY;
 
             BigInteger Xp = curve.field - point.x;

--- a/Eduard/Security/Curves/MontyMath.cs
+++ b/Eduard/Security/Curves/MontyMath.cs
@@ -36,13 +36,13 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Add(MontgomeryCurve curve, ECPoint left, ECPoint right)
         {
-            if (left == ECPoint.POINT_INFINITY && right == ECPoint.POINT_INFINITY)
+            if (!left.isOnCurve && !right.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
-            if (left == ECPoint.POINT_INFINITY)
+            if (!left.isOnCurve)
                 return right;
 
-            if (right == ECPoint.POINT_INFINITY)
+            if (!right.isOnCurve)
                 return left;
 
             BigInteger lambda = -1;
@@ -127,7 +127,7 @@ namespace Eduard.Security.Curves
                     "Scalar multiplier must be non-negative.", 
                     nameof(k));
 
-            if (k == 0 || point == ECPoint.POINT_INFINITY)
+            if (k == 0 || !point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             ECPoint affinePoint = point;
@@ -180,7 +180,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Negate(MontgomeryCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             return new ECPoint(point.x, curve.field - point.y);

--- a/Eduard/Security/Curves/TwistedEdwardsMath.cs
+++ b/Eduard/Security/Curves/TwistedEdwardsMath.cs
@@ -63,7 +63,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Multiply(TwistedEdwardsCurve curve, BigInteger k, ECPoint point, ECMode opMode = ECMode.EC_STANDARD_AFFINE, bool securityCheck = false)
         {
-            if (k == 0 || point == ECPoint.POINT_INFINITY)
+            if (k == 0 || !point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             string[] pointErrors = new string[]
@@ -217,13 +217,13 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Add(TwistedEdwardsCurve curve, ECPoint left, ECPoint right)
         {
-            if (left == ECPoint.POINT_INFINITY && right == ECPoint.POINT_INFINITY)
+            if (!left.isOnCurve && !right.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
-            if (left == ECPoint.POINT_INFINITY)
+            if (!left.isOnCurve)
                 return right;
 
-            if (right == ECPoint.POINT_INFINITY)
+            if (!right.isOnCurve)
                 return left;
 
             if (left == Negate(curve, right))
@@ -376,7 +376,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint Negate(TwistedEdwardsCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             return new ECPoint(curve.field - point.x, point.y);

--- a/Eduard/Security/Curves/Wei3Math.cs
+++ b/Eduard/Security/Curves/Wei3Math.cs
@@ -40,20 +40,20 @@ namespace Eduard.Security.Curves
         public static ECPoint3w Add(EllipticCurve curve, ECPoint3w left, ECPoint3w right)
         {
             if (left == right) return Doubling(curve, left);
-            if (left == ECPoint3w.POINT_INFINITY) return right;
-            if (right == ECPoint3w.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
-            BigInteger B1 = BarrettReducer.MultMod(right.z, right.z);
-            BigInteger A1 = BarrettReducer.MultMod(left.x, B1);
+            BigInteger B1 = BarrettReducer.MultMod(right.Z, right.Z);
+            BigInteger A1 = BarrettReducer.MultMod(left.X, B1);
 
-            BigInteger B2 = BarrettReducer.MultMod(left.z, left.z);
-            BigInteger A2 = BarrettReducer.MultMod(right.x, B2);
+            BigInteger B2 = BarrettReducer.MultMod(left.Z, left.Z);
+            BigInteger A2 = BarrettReducer.MultMod(right.X, B2);
 
-            BigInteger B3 = BarrettReducer.MultMod(B1, right.z);
-            BigInteger A3 = BarrettReducer.MultMod(left.y, B3);
+            BigInteger B3 = BarrettReducer.MultMod(B1, right.Z);
+            BigInteger A3 = BarrettReducer.MultMod(left.Y, B3);
 
-            BigInteger B4 = BarrettReducer.MultMod(B2, left.z);
-            BigInteger A4 = BarrettReducer.MultMod(right.y, B4);
+            BigInteger B4 = BarrettReducer.MultMod(B2, left.Z);
+            BigInteger A4 = BarrettReducer.MultMod(right.Y, B4);
 
             BigInteger A5 = BarrettReducer.SubMod(A2, A1);
             BigInteger A6 = BarrettReducer.SubMod(A4, A3);
@@ -74,7 +74,7 @@ namespace Eduard.Security.Curves
             BigInteger B9 = BarrettReducer.MultMod(A6, B8);
             BigInteger Y = BarrettReducer.SubMod(B9, B7);
 
-            BigInteger Z12 = BarrettReducer.MultMod(left.z, right.z);
+            BigInteger Z12 = BarrettReducer.MultMod(left.Z, right.Z);
             BigInteger Z = BarrettReducer.MultMod(A5, Z12);
 
             if (Z == 0) return ECPoint3w.POINT_INFINITY;
@@ -102,11 +102,12 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint3w Doubling(EllipticCurve curve, ECPoint3w jacobianPoint)
         {
-            if (jacobianPoint == ECPoint3w.POINT_INFINITY) return ECPoint3w.POINT_INFINITY;
+            if (!jacobianPoint.isOnCurve) 
+                return ECPoint3w.POINT_INFINITY;
             BigInteger p = curve.field;
 
-            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.y);
-            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.x, A1);
+            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Y);
+            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.X, A1);
 
             BigInteger A2 = BarrettReducer.MultMod(4, B1);
             BigInteger B2 = BarrettReducer.MultMod(A1, A1);
@@ -116,8 +117,8 @@ namespace Eduard.Security.Curves
 
             if (curve.a != p - 3)
             {
-                BigInteger X12 = BarrettReducer.MultMod(jacobianPoint.x, jacobianPoint.x);
-                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.z, jacobianPoint.z);
+                BigInteger X12 = BarrettReducer.MultMod(jacobianPoint.X, jacobianPoint.X);
+                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.Z, jacobianPoint.Z);
                 BigInteger Z21 = BarrettReducer.MultMod(Z12, Z12);
 
                 BigInteger B3 = BarrettReducer.MultMod(curve.a, Z21);
@@ -127,9 +128,9 @@ namespace Eduard.Security.Curves
             else
             {
                 /* special case when Weierstrass curve parameter a = -3 */
-                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.z, jacobianPoint.z);
-                BigInteger B3 = BarrettReducer.SubMod(jacobianPoint.x, Z12);
-                BigInteger B4 = BarrettReducer.AddMod(jacobianPoint.x, Z12);
+                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.Z, jacobianPoint.Z);
+                BigInteger B3 = BarrettReducer.SubMod(jacobianPoint.X, Z12);
+                BigInteger B4 = BarrettReducer.AddMod(jacobianPoint.X, Z12);
                 A4 = BarrettReducer.MultMod(B3, B4);
                 A4 = BarrettReducer.MultMod(3, A4);
             }
@@ -143,7 +144,7 @@ namespace Eduard.Security.Curves
             BigInteger B5 = BarrettReducer.MultMod(A4, A6);
             BigInteger Y = BarrettReducer.SubMod(B5, A3);
 
-            BigInteger B6 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.z);
+            BigInteger B6 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Z);
             BigInteger Z = BarrettReducer.AddMod(B6, B6);
 
             if (Z == 0) return ECPoint3w.POINT_INFINITY;
@@ -163,8 +164,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint3w Negate(EllipticCurve curve, ECPoint3w point)
         {
-            if (point == ECPoint3w.POINT_INFINITY) return ECPoint3w.POINT_INFINITY;
-            return new ECPoint3w(point.x, curve.field - point.y, point.z);
+            if (!point.isOnCurve) return ECPoint3w.POINT_INFINITY;
+            return new ECPoint3w(point.X, curve.field - point.Y, point.Z);
         }
     }
 

--- a/Eduard/Security/Curves/Wei3Math.cs
+++ b/Eduard/Security/Curves/Wei3Math.cs
@@ -43,17 +43,17 @@ namespace Eduard.Security.Curves
             if (!left.isOnCurve) return right;
             if (!right.isOnCurve) return left;
 
-            BigInteger B1 = BarrettReducer.MultMod(right.Z, right.Z);
-            BigInteger A1 = BarrettReducer.MultMod(left.X, B1);
+            BigInteger B1 = BarrettReducer.MultMod(right.z, right.z);
+            BigInteger A1 = BarrettReducer.MultMod(left.x, B1);
 
-            BigInteger B2 = BarrettReducer.MultMod(left.Z, left.Z);
-            BigInteger A2 = BarrettReducer.MultMod(right.X, B2);
+            BigInteger B2 = BarrettReducer.MultMod(left.z, left.z);
+            BigInteger A2 = BarrettReducer.MultMod(right.x, B2);
 
-            BigInteger B3 = BarrettReducer.MultMod(B1, right.Z);
-            BigInteger A3 = BarrettReducer.MultMod(left.Y, B3);
+            BigInteger B3 = BarrettReducer.MultMod(B1, right.z);
+            BigInteger A3 = BarrettReducer.MultMod(left.y, B3);
 
-            BigInteger B4 = BarrettReducer.MultMod(B2, left.Z);
-            BigInteger A4 = BarrettReducer.MultMod(right.Y, B4);
+            BigInteger B4 = BarrettReducer.MultMod(B2, left.z);
+            BigInteger A4 = BarrettReducer.MultMod(right.y, B4);
 
             BigInteger A5 = BarrettReducer.SubMod(A2, A1);
             BigInteger A6 = BarrettReducer.SubMod(A4, A3);
@@ -74,7 +74,7 @@ namespace Eduard.Security.Curves
             BigInteger B9 = BarrettReducer.MultMod(A6, B8);
             BigInteger Y = BarrettReducer.SubMod(B9, B7);
 
-            BigInteger Z12 = BarrettReducer.MultMod(left.Z, right.Z);
+            BigInteger Z12 = BarrettReducer.MultMod(left.z, right.z);
             BigInteger Z = BarrettReducer.MultMod(A5, Z12);
 
             if (Z == 0) return ECPoint3w.POINT_INFINITY;
@@ -106,8 +106,8 @@ namespace Eduard.Security.Curves
                 return ECPoint3w.POINT_INFINITY;
             BigInteger p = curve.field;
 
-            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Y);
-            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.X, A1);
+            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.y);
+            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.x, A1);
 
             BigInteger A2 = BarrettReducer.MultMod(4, B1);
             BigInteger B2 = BarrettReducer.MultMod(A1, A1);
@@ -117,8 +117,8 @@ namespace Eduard.Security.Curves
 
             if (curve.a != p - 3)
             {
-                BigInteger X12 = BarrettReducer.MultMod(jacobianPoint.X, jacobianPoint.X);
-                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.Z, jacobianPoint.Z);
+                BigInteger X12 = BarrettReducer.MultMod(jacobianPoint.x, jacobianPoint.x);
+                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.z, jacobianPoint.z);
                 BigInteger Z21 = BarrettReducer.MultMod(Z12, Z12);
 
                 BigInteger B3 = BarrettReducer.MultMod(curve.a, Z21);
@@ -128,9 +128,9 @@ namespace Eduard.Security.Curves
             else
             {
                 /* special case when Weierstrass curve parameter a = -3 */
-                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.Z, jacobianPoint.Z);
-                BigInteger B3 = BarrettReducer.SubMod(jacobianPoint.X, Z12);
-                BigInteger B4 = BarrettReducer.AddMod(jacobianPoint.X, Z12);
+                BigInteger Z12 = BarrettReducer.MultMod(jacobianPoint.z, jacobianPoint.z);
+                BigInteger B3 = BarrettReducer.SubMod(jacobianPoint.x, Z12);
+                BigInteger B4 = BarrettReducer.AddMod(jacobianPoint.x, Z12);
                 A4 = BarrettReducer.MultMod(B3, B4);
                 A4 = BarrettReducer.MultMod(3, A4);
             }
@@ -144,7 +144,7 @@ namespace Eduard.Security.Curves
             BigInteger B5 = BarrettReducer.MultMod(A4, A6);
             BigInteger Y = BarrettReducer.SubMod(B5, A3);
 
-            BigInteger B6 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Z);
+            BigInteger B6 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.z);
             BigInteger Z = BarrettReducer.AddMod(B6, B6);
 
             if (Z == 0) return ECPoint3w.POINT_INFINITY;
@@ -165,7 +165,7 @@ namespace Eduard.Security.Curves
         public static ECPoint3w Negate(EllipticCurve curve, ECPoint3w point)
         {
             if (!point.isOnCurve) return ECPoint3w.POINT_INFINITY;
-            return new ECPoint3w(point.X, curve.field - point.Y, point.Z);
+            return new ECPoint3w(point.x, curve.field - point.y, point.z);
         }
     }
 

--- a/Eduard/Security/Curves/Wei4Math.cs
+++ b/Eduard/Security/Curves/Wei4Math.cs
@@ -44,20 +44,22 @@ namespace Eduard.Security.Curves
         /// <returns>The sum of the two points in modified Jacobian coordinates.</returns>
         public static ECPoint4w Add(EllipticCurve curve, ECPoint4w left, ECPoint4w right)
         {
-            if (left == right) return Doubling(curve, right);
-            if (left == ECPoint4w.POINT_INFINITY) return right;
-            if (right == ECPoint4w.POINT_INFINITY) return left;
+            if (left == right) 
+                return Doubling(curve, right);
 
-            BigInteger A1 = BarrettReducer.MultMod(left.z, left.z);
-            BigInteger A2 = BarrettReducer.MultMod(right.z, right.z);
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
-            BigInteger A3 = BarrettReducer.MultMod(left.x, A2);
-            BigInteger A4 = BarrettReducer.MultMod(right.x, A1);
+            BigInteger A1 = BarrettReducer.MultMod(left.Z, left.Z);
+            BigInteger A2 = BarrettReducer.MultMod(right.Z, right.Z);
 
-            BigInteger B1 = BarrettReducer.MultMod(left.y, right.z);
+            BigInteger A3 = BarrettReducer.MultMod(left.X, A2);
+            BigInteger A4 = BarrettReducer.MultMod(right.X, A1);
+
+            BigInteger B1 = BarrettReducer.MultMod(left.Y, right.Z);
             BigInteger A5 = BarrettReducer.MultMod(B1, A2);
 
-            BigInteger B2 = BarrettReducer.MultMod(right.y, left.z);
+            BigInteger B2 = BarrettReducer.MultMod(right.Y, left.Z);
             BigInteger A6 = BarrettReducer.MultMod(B2, A1);
 
             BigInteger A7 = BarrettReducer.SubMod(A4, A3);
@@ -79,7 +81,7 @@ namespace Eduard.Security.Curves
             BigInteger B8 = BarrettReducer.MultMod(A5, A9);
             BigInteger Y = BarrettReducer.SubMod(B7, B8);
 
-            BigInteger B9 = BarrettReducer.MultMod(left.z, right.z);
+            BigInteger B9 = BarrettReducer.MultMod(left.Z, right.Z);
             BigInteger Z = BarrettReducer.MultMod(A7, B9);
 
             if (Z == 0) return ECPoint4w.POINT_INFINITY;
@@ -102,16 +104,16 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4w Doubling(EllipticCurve curve, ECPoint4w jacobianPoint)
         {
-            if (jacobianPoint == ECPoint4w.POINT_INFINITY) 
+            if (!jacobianPoint.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
-            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.x, jacobianPoint.x);
-            BigInteger A2 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.y);
+            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.X, jacobianPoint.X);
+            BigInteger A2 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Y);
 
             BigInteger A3t = BarrettReducer.MultMod(A2, A2);
             BigInteger A3 = BarrettReducer.MultMod(8, A3t);
 
-            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.x, A2);
+            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.X, A2);
             BigInteger A4 = BarrettReducer.MultMod(4, B1);
 
             BigInteger B2 = BarrettReducer.MultMod(3, A1);
@@ -126,7 +128,7 @@ namespace Eduard.Security.Curves
             BigInteger Y = BarrettReducer.MultMod(A5, Yt);
             Y = BarrettReducer.SubMod(Y, A3);
 
-            BigInteger YZ = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.z);
+            BigInteger YZ = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Z);
             BigInteger Z = BarrettReducer.AddMod(YZ, YZ);
 
             if (Z == 0) return ECPoint4w.POINT_INFINITY;
@@ -149,8 +151,8 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint4w Negate(EllipticCurve curve, ECPoint4w point)
         {
-            if (point == ECPoint4w.POINT_INFINITY) return ECPoint4w.POINT_INFINITY;
-            return new ECPoint4w(point.x, curve.field - point.y, point.z, point.aZ4);
+            if (!point.isOnCurve) return ECPoint4w.POINT_INFINITY;
+            return new ECPoint4w(point.X, curve.field - point.Y, point.Z, point.aZ4);
         }
     }
 

--- a/Eduard/Security/Curves/Wei4Math.cs
+++ b/Eduard/Security/Curves/Wei4Math.cs
@@ -50,16 +50,16 @@ namespace Eduard.Security.Curves
             if (!left.isOnCurve) return right;
             if (!right.isOnCurve) return left;
 
-            BigInteger A1 = BarrettReducer.MultMod(left.Z, left.Z);
-            BigInteger A2 = BarrettReducer.MultMod(right.Z, right.Z);
+            BigInteger A1 = BarrettReducer.MultMod(left.z, left.z);
+            BigInteger A2 = BarrettReducer.MultMod(right.z, right.z);
 
-            BigInteger A3 = BarrettReducer.MultMod(left.X, A2);
-            BigInteger A4 = BarrettReducer.MultMod(right.X, A1);
+            BigInteger A3 = BarrettReducer.MultMod(left.x, A2);
+            BigInteger A4 = BarrettReducer.MultMod(right.x, A1);
 
-            BigInteger B1 = BarrettReducer.MultMod(left.Y, right.Z);
+            BigInteger B1 = BarrettReducer.MultMod(left.y, right.z);
             BigInteger A5 = BarrettReducer.MultMod(B1, A2);
 
-            BigInteger B2 = BarrettReducer.MultMod(right.Y, left.Z);
+            BigInteger B2 = BarrettReducer.MultMod(right.y, left.z);
             BigInteger A6 = BarrettReducer.MultMod(B2, A1);
 
             BigInteger A7 = BarrettReducer.SubMod(A4, A3);
@@ -81,7 +81,7 @@ namespace Eduard.Security.Curves
             BigInteger B8 = BarrettReducer.MultMod(A5, A9);
             BigInteger Y = BarrettReducer.SubMod(B7, B8);
 
-            BigInteger B9 = BarrettReducer.MultMod(left.Z, right.Z);
+            BigInteger B9 = BarrettReducer.MultMod(left.z, right.z);
             BigInteger Z = BarrettReducer.MultMod(A7, B9);
 
             if (Z == 0) return ECPoint4w.POINT_INFINITY;
@@ -107,17 +107,17 @@ namespace Eduard.Security.Curves
             if (!jacobianPoint.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
-            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.X, jacobianPoint.X);
-            BigInteger A2 = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Y);
+            BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.x, jacobianPoint.x);
+            BigInteger A2 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.y);
 
             BigInteger A3t = BarrettReducer.MultMod(A2, A2);
             BigInteger A3 = BarrettReducer.MultMod(8, A3t);
 
-            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.X, A2);
+            BigInteger B1 = BarrettReducer.MultMod(jacobianPoint.x, A2);
             BigInteger A4 = BarrettReducer.MultMod(4, B1);
 
             BigInteger B2 = BarrettReducer.MultMod(3, A1);
-            BigInteger A5 = BarrettReducer.AddMod(B2, jacobianPoint.aZ4);
+            BigInteger A5 = BarrettReducer.AddMod(B2, jacobianPoint.az4);
 
             BigInteger A6 = BarrettReducer.MultMod(A5, A5);
             BigInteger Xt = BarrettReducer.AddMod(A4, A4);
@@ -128,11 +128,11 @@ namespace Eduard.Security.Curves
             BigInteger Y = BarrettReducer.MultMod(A5, Yt);
             Y = BarrettReducer.SubMod(Y, A3);
 
-            BigInteger YZ = BarrettReducer.MultMod(jacobianPoint.Y, jacobianPoint.Z);
+            BigInteger YZ = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.z);
             BigInteger Z = BarrettReducer.AddMod(YZ, YZ);
 
             if (Z == 0) return ECPoint4w.POINT_INFINITY;
-            BigInteger Zt = BarrettReducer.MultMod(A3, jacobianPoint.aZ4);
+            BigInteger Zt = BarrettReducer.MultMod(A3, jacobianPoint.az4);
 
             BigInteger aZ4 = BarrettReducer.AddMod(Zt, Zt);
             return new ECPoint4w(X, Y, Z, aZ4);
@@ -152,7 +152,7 @@ namespace Eduard.Security.Curves
         public static ECPoint4w Negate(EllipticCurve curve, ECPoint4w point)
         {
             if (!point.isOnCurve) return ECPoint4w.POINT_INFINITY;
-            return new ECPoint4w(point.X, curve.field - point.Y, point.Z, point.aZ4);
+            return new ECPoint4w(point.x, curve.field - point.y, point.z, point.az4);
         }
     }
 

--- a/Eduard/Security/Curves/Wei5Math.cs
+++ b/Eduard/Security/Curves/Wei5Math.cs
@@ -46,8 +46,8 @@ namespace Eduard.Security.Curves
         public static ECPoint5w Add(EllipticCurve curve, ECPoint5w left, ECPoint5w right)
         {
             if (left == right) return Doubling(curve, right);
-            if (left == ECPoint5w.POINT_INFINITY) return right;
-            if (right == ECPoint5w.POINT_INFINITY) return left;
+            if (!left.isOnCurve) return right;
+            if (!right.isOnCurve) return left;
 
             BigInteger A1 = BarrettReducer.MultMod(left.x, right.z2);
             BigInteger A2 = BarrettReducer.MultMod(right.x, left.z2);
@@ -101,7 +101,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint5w Doubling(EllipticCurve curve, ECPoint5w jacobianPoint)
         {
-            if (jacobianPoint == ECPoint5w.POINT_INFINITY) return ECPoint5w.POINT_INFINITY;
+            if (!jacobianPoint.isOnCurve) return ECPoint5w.POINT_INFINITY;
             BigInteger p = curve.field;
 
             BigInteger A1 = BarrettReducer.MultMod(jacobianPoint.y, jacobianPoint.y);
@@ -163,7 +163,7 @@ namespace Eduard.Security.Curves
         /// </remarks>
         public static ECPoint5w Negate(EllipticCurve curve, ECPoint5w point)
         {
-            if (point == ECPoint5w.POINT_INFINITY) return ECPoint5w.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint5w.POINT_INFINITY;
             return new ECPoint5w(point.x, curve.field - point.y, point.z, point.z2, point.z3);
         }
     }

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -28,12 +28,12 @@ namespace Eduard.Security.Extensions
             if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
-            BigInteger inv_Z = BarrettReducer.InvMod(point.Z);
+            BigInteger inv_Z = BarrettReducer.InvMod(point.z);
             BigInteger iZ2 = BarrettReducer.MultMod(inv_Z, inv_Z);
             BigInteger iZ3 = BarrettReducer.MultMod(iZ2, inv_Z);
 
-            BigInteger X = BarrettReducer.MultMod(point.X, iZ2);
-            BigInteger Y = BarrettReducer.MultMod(point.Y, iZ3);
+            BigInteger X = BarrettReducer.MultMod(point.x, iZ2);
+            BigInteger Y = BarrettReducer.MultMod(point.y, iZ3);
             return new ECPoint(X, Y);
         }
 
@@ -224,20 +224,13 @@ namespace Eduard.Security.Extensions
         /// <remarks>
         /// Discards the cached aZ^4 value when switching to coordinate systems that don't support it.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero aZ^4.
-        /// </exception>
         public static ECPoint3w ToJacobian(this EllipticCurve curve, ECPoint4w point)
         {
-            if (point.Z == 0 && point.aZ4 != 0)
-                throw new InvalidOperationException(
-                    "Point at infinity must have aZ^4 = 0.");
-
             if (!point.isOnCurve) 
                 return ECPoint3w.POINT_INFINITY;
 
-            ECPoint3w jacobianPoint = new ECPoint3w(point.X,
-                point.Y, point.Z);
+            ECPoint3w jacobianPoint = new ECPoint3w(point.x,
+                point.y, point.z);
 
             return jacobianPoint;
         }
@@ -335,25 +328,17 @@ namespace Eduard.Security.Extensions
         /// Recovers affine coordinates as x = X/Z^2, y = Y/Z^3 using a single modular <br/>
         /// inversion. The cached aZ^4 value is discarded during affine recovery.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero aZ^4.
-        /// </exception>
         public static ECPoint ToAffine(this EllipticCurve curve, ECPoint4w point)
         {
-            /* invalid point at infinity */
-            if (point.Z == 0 && point.aZ4 != 0)
-                throw new InvalidOperationException(
-                    "Point at infinity must have aZ^4 = 0.");
-
             if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
-            BigInteger inv_Z = BarrettReducer.InvMod(point.Z);
+            BigInteger inv_Z = BarrettReducer.InvMod(point.z);
             BigInteger iZ2 = BarrettReducer.MultMod(inv_Z, inv_Z);
             BigInteger iZ3 = BarrettReducer.MultMod(iZ2, inv_Z);
 
-            BigInteger X = BarrettReducer.MultMod(point.X, iZ2);
-            BigInteger Y = BarrettReducer.MultMod(point.Y, iZ3);
+            BigInteger X = BarrettReducer.MultMod(point.x, iZ2);
+            BigInteger Y = BarrettReducer.MultMod(point.y, iZ3);
             return new ECPoint(X, Y);
         }
 
@@ -427,12 +412,12 @@ namespace Eduard.Security.Extensions
             if (!point.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
-            BigInteger Z2 = BarrettReducer.MultMod(point.Z, point.Z);
+            BigInteger Z2 = BarrettReducer.MultMod(point.z, point.z);
             BigInteger Z4 = BarrettReducer.MultMod(Z2, Z2);
             BigInteger aZ4 = BarrettReducer.MultMod(curve.a, Z4);
 
-            ECPoint4w modifiedJacobianPoint = new ECPoint4w(point.X, 
-                point.Y, point.Z, aZ4);
+            ECPoint4w modifiedJacobianPoint = new ECPoint4w(point.x, 
+                point.y, point.z, aZ4);
             return modifiedJacobianPoint;
         }
     }

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -47,17 +47,9 @@ namespace Eduard.Security.Extensions
         /// Performs: x = X/Z, y = Y/Z. The identity element (0, 1) maps to point at infinity. <br/>
         /// This representation is optimal for unified addition formulas (Hisil et al., ASIACRYPT 2008).
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero T (Z=0 but T != 0).
-        /// </exception>
         public static ECPoint ToAffine(this TwistedEdwardsCurve curve, ECPoint4 point)
         {
-            if (point.z == 0 && point.t != 0)
-                throw new InvalidOperationException(
-                    "Point at infinity must have" 
-                    + " T = 0 when Z = 0.");
-
-            if (point == ECPoint4.POINT_INFINITY || point.z == 0)
+            if (!point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             BigInteger inv_Z = BarrettReducer.InvMod(point.z);
@@ -150,11 +142,8 @@ namespace Eduard.Security.Extensions
             if(!point.isOnCurve)
                 return ECPoint4.POINT_INFINITY;
 
-            var res = new ECPoint4();
-            res.x = point.x; res.y = point.y;
-
-            /* T is not used in point doubling formula */
-            res.z = point.z; res.t = 0;
+            var res = new ECPoint4(
+                point.x, point.y, 0, point.z);
             return res;
         }
 
@@ -178,17 +167,9 @@ namespace Eduard.Security.Extensions
         /// <param name="curve">The twisted Edwards curve context.</param>
         /// <param name="point">The point in extended coordinates (X, Y, T, Z).</param>
         /// <returns>Homogeneous coordinates (X, Y, Z).</returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero T (Z=0 but T != 0).
-        /// </exception>
         public static ECPoint3 ToProjective(this TwistedEdwardsCurve curve, ECPoint4 point)
         {
-            if (point.z == 0 && point.t != 0)
-                throw new InvalidOperationException(
-                    "Point at infinity must have " 
-                    + "T = 0 when Z = 0.");
-
-            if (point == ECPoint4.POINT_INFINITY)
+            if (!point.isOnCurve)
                 return ECPoint3.POINT_INFINITY;
 
             return new ECPoint3(point.x, point.y, point.z);

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -104,7 +104,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint4 ToExtendedProjective(this TwistedEdwardsCurve curve, ECPoint point)
         {
-            if(point == ECPoint.POINT_INFINITY || (point.x == 0 && point.y == 1)) 
+            if(!point.isOnCurve || (point.x == 0 && point.y == 1)) 
                 return ECPoint4.POINT_INFINITY;
 
             BigInteger t = BarrettReducer.MultMod(point.x, point.y);
@@ -166,7 +166,7 @@ namespace Eduard.Security.Extensions
         /// <returns>Homogeneous coordinates (X, Y, Z) with Z = 1.</returns>
         public static ECPoint3 ToProjective(this TwistedEdwardsCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY || (point.x == 0 && point.y == 1))
+            if (!point.isOnCurve || (point.x == 0 && point.y == 1))
                 return ECPoint3.POINT_INFINITY;
 
             return new ECPoint3(point.x, point.y, 1);
@@ -206,7 +206,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint3w ToJacobian(this EllipticCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY) 
+            if (!point.isOnCurve) 
                 return ECPoint3w.POINT_INFINITY;
 
             ECPoint3w jacobianPoint = new ECPoint3w(point.GetAffineX(),
@@ -316,7 +316,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint5w ToJacobianChudnovsky(this EllipticCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY) 
+            if (!point.isOnCurve) 
                 return ECPoint5w.POINT_INFINITY;
 
             ECPoint5w jacobianChudnovskyPoint = new ECPoint5w(point.GetAffineX(), 
@@ -371,7 +371,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint4w ToModifiedJacobian(this EllipticCurve curve, ECPoint point)
         {
-            if (point == ECPoint.POINT_INFINITY) 
+            if (!point.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
             ECPoint4w modifiedJacobianPoint = new ECPoint4w(

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -80,7 +80,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint ToAffine(this TwistedEdwardsCurve curve, ECPoint3 point)
         {
-            if (point == ECPoint3.POINT_INFINITY || point.z == 0)
+            if (!point.isOnCurve)
                 return ECPoint.POINT_INFINITY;
 
             BigInteger inv_Z = BarrettReducer.InvMod(point.z);
@@ -123,7 +123,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint4 ToExtendedProjective(this TwistedEdwardsCurve curve, ECPoint3 point)
         {
-            if (point == ECPoint3.POINT_INFINITY || point.z == 0)
+            if (!point.isOnCurve)
                 return ECPoint4.POINT_INFINITY;
 
             BigInteger xz = BarrettReducer.MultMod(point.x, point.z);
@@ -147,7 +147,7 @@ namespace Eduard.Security.Extensions
         public static ECPoint4 GetPointCopy(this TwistedEdwardsCurve curve, ECPoint3 point)
         {
             /* point at infinity */
-            if(point == ECPoint3.POINT_INFINITY || point.z == 0)
+            if(!point.isOnCurve)
                 return ECPoint4.POINT_INFINITY;
 
             var res = new ECPoint4();

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -28,12 +28,12 @@ namespace Eduard.Security.Extensions
             if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
-            BigInteger inv_Z = BarrettReducer.InvMod(point.z);
+            BigInteger inv_Z = BarrettReducer.InvMod(point.Z);
             BigInteger iZ2 = BarrettReducer.MultMod(inv_Z, inv_Z);
             BigInteger iZ3 = BarrettReducer.MultMod(iZ2, inv_Z);
 
-            BigInteger X = BarrettReducer.MultMod(point.x, iZ2);
-            BigInteger Y = BarrettReducer.MultMod(point.y, iZ3);
+            BigInteger X = BarrettReducer.MultMod(point.X, iZ2);
+            BigInteger Y = BarrettReducer.MultMod(point.Y, iZ3);
             return new ECPoint(X, Y);
         }
 
@@ -427,12 +427,12 @@ namespace Eduard.Security.Extensions
             if (!point.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
-            BigInteger Z2 = BarrettReducer.MultMod(point.z, point.z);
+            BigInteger Z2 = BarrettReducer.MultMod(point.Z, point.Z);
             BigInteger Z4 = BarrettReducer.MultMod(Z2, Z2);
             BigInteger aZ4 = BarrettReducer.MultMod(curve.a, Z4);
 
-            ECPoint4w modifiedJacobianPoint = new ECPoint4w(point.x, 
-                point.y, point.z, aZ4);
+            ECPoint4w modifiedJacobianPoint = new ECPoint4w(point.X, 
+                point.Y, point.Z, aZ4);
             return modifiedJacobianPoint;
         }
     }

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -244,17 +244,9 @@ namespace Eduard.Security.Extensions
         /// <remarks>
         /// Discards the precomputed Z^2 and Z^3 powers when converting to simpler representations.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero Z^2 or Z^3, or when consistency checks fail.
-        /// </exception>
         public static ECPoint3w ToJacobian(this EllipticCurve curve, ECPoint5w point)
         {
-            if (point.z == 0 && (point.z2 != 0 || point.z3 != 0))
-                throw new InvalidOperationException(
-                    "Point at infinity must have "
-                    + "Z^2 = 0 and Z^3 = 0.");
-
-            if (point == ECPoint5w.POINT_INFINITY || point.z == 0)
+            if (!point.isOnCurve)
                 return ECPoint3w.POINT_INFINITY;
 
             ECPoint3w jacobianPoint = new ECPoint3w(point.x,
@@ -273,17 +265,9 @@ namespace Eduard.Security.Extensions
         /// Uses the precomputed Z^2 and Z^3 values to avoid recomputing powers during conversion, <br/>
         /// improving efficiency when converting from window method accumulator points.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero Z^2 or Z^3, or when consistency checks fail.
-        /// </exception>
         public static ECPoint ToAffine(this EllipticCurve curve, ECPoint5w point)
-        {
-            if (point.z == 0 && (point.z2 != 0 || point.z3 != 0))
-                throw new InvalidOperationException(
-                    "Point at infinity must have " 
-                    + "Z^2 = 0 and Z^3 = 0.");
-            
-            if (point == ECPoint5w.POINT_INFINITY || point.z == 0) 
+        {    
+            if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
             BigInteger Z5 = BarrettReducer.MultMod(point.z2, point.z3);
@@ -374,18 +358,9 @@ namespace Eduard.Security.Extensions
         /// Computes aZ^4 from the precomputed Z^2 value, avoiding redundant squaring operations. <br/>
         /// Used when transitioning from window precomputation to modified Jacobian doubling.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown when point at infinity has non-zero Z^2 or Z^3, or when consistency checks fail.
-        /// </exception>
         public static ECPoint4w ToModifiedJacobian(this EllipticCurve curve, ECPoint5w point)
         {
-            /* invalid point at infinity */
-            if (point.z == 0 && (point.z2 != 0 || point.z3 != 0))
-                throw new InvalidOperationException(
-                    "Point at infinity must have "
-                    + "Z^2 = 0 and Z^3 = 0.");
-
-            if (point == ECPoint5w.POINT_INFINITY || point.z == 0) 
+            if (!point.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
             BigInteger Z4 = BarrettReducer.MultMod(point.z2, point.z2);

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -25,7 +25,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint ToAffine(this EllipticCurve curve, ECPoint3w point)
         {
-            if (point == ECPoint3w.POINT_INFINITY || point.z == 0) 
+            if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
             BigInteger inv_Z = BarrettReducer.InvMod(point.z);
@@ -104,7 +104,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint4 ToExtendedProjective(this TwistedEdwardsCurve curve, ECPoint point)
         {
-            if(!point.isOnCurve || (point.x == 0 && point.y == 1)) 
+            if(!point.isOnCurve) 
                 return ECPoint4.POINT_INFINITY;
 
             BigInteger t = BarrettReducer.MultMod(point.x, point.y);
@@ -424,7 +424,7 @@ namespace Eduard.Security.Extensions
         /// </remarks>
         public static ECPoint4w ToModifiedJacobian(this EllipticCurve curve, ECPoint3w point)
         {
-            if (point == ECPoint3w.POINT_INFINITY || point.z == 0) 
+            if (!point.isOnCurve) 
                 return ECPoint4w.POINT_INFINITY;
 
             BigInteger Z2 = BarrettReducer.MultMod(point.z, point.z);

--- a/Eduard/Security/Extensions/ECPointExtensions.cs
+++ b/Eduard/Security/Extensions/ECPointExtensions.cs
@@ -166,7 +166,7 @@ namespace Eduard.Security.Extensions
         /// <returns>Homogeneous coordinates (X, Y, Z) with Z = 1.</returns>
         public static ECPoint3 ToProjective(this TwistedEdwardsCurve curve, ECPoint point)
         {
-            if (!point.isOnCurve || (point.x == 0 && point.y == 1))
+            if (!point.isOnCurve)
                 return ECPoint3.POINT_INFINITY;
 
             return new ECPoint3(point.x, point.y, 1);
@@ -229,15 +229,15 @@ namespace Eduard.Security.Extensions
         /// </exception>
         public static ECPoint3w ToJacobian(this EllipticCurve curve, ECPoint4w point)
         {
-            if (point.z == 0 && point.aZ4 != 0)
+            if (point.Z == 0 && point.aZ4 != 0)
                 throw new InvalidOperationException(
                     "Point at infinity must have aZ^4 = 0.");
 
-            if (point == ECPoint4w.POINT_INFINITY || point.z == 0) 
+            if (!point.isOnCurve) 
                 return ECPoint3w.POINT_INFINITY;
 
-            ECPoint3w jacobianPoint = new ECPoint3w(point.x,
-                point.y, point.z);
+            ECPoint3w jacobianPoint = new ECPoint3w(point.X,
+                point.Y, point.Z);
 
             return jacobianPoint;
         }
@@ -341,19 +341,19 @@ namespace Eduard.Security.Extensions
         public static ECPoint ToAffine(this EllipticCurve curve, ECPoint4w point)
         {
             /* invalid point at infinity */
-            if (point.z == 0 && point.aZ4 != 0)
+            if (point.Z == 0 && point.aZ4 != 0)
                 throw new InvalidOperationException(
                     "Point at infinity must have aZ^4 = 0.");
 
-            if (point == ECPoint4w.POINT_INFINITY || point.z == 0) 
+            if (!point.isOnCurve) 
                 return ECPoint.POINT_INFINITY;
 
-            BigInteger inv_Z = BarrettReducer.InvMod(point.z);
+            BigInteger inv_Z = BarrettReducer.InvMod(point.Z);
             BigInteger iZ2 = BarrettReducer.MultMod(inv_Z, inv_Z);
             BigInteger iZ3 = BarrettReducer.MultMod(iZ2, inv_Z);
 
-            BigInteger X = BarrettReducer.MultMod(point.x, iZ2);
-            BigInteger Y = BarrettReducer.MultMod(point.y, iZ3);
+            BigInteger X = BarrettReducer.MultMod(point.X, iZ2);
+            BigInteger Y = BarrettReducer.MultMod(point.Y, iZ3);
             return new ECPoint(X, Y);
         }
 

--- a/Eduard/Security/Extensions/EllipticCurveExtensions.cs
+++ b/Eduard/Security/Extensions/EllipticCurveExtensions.cs
@@ -121,7 +121,7 @@ namespace Eduard.Security.Extensions
             BigInteger p = curve.field;
 
             /* map the point at infinity on a Montgomery curve to its equivalent on the Weierstrass curve */
-            if (point == ECPoint.POINT_INFINITY) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
 
             var roots = new List<BigInteger>();
             Polynomial W = new Polynomial(1, 0, curve.a, curve.b);
@@ -285,7 +285,7 @@ namespace Eduard.Security.Extensions
             BigInteger p = curve.field;
 
             /* map the point at infinity on a Montgomery curve to its equivalent on the Weierstrass curve */
-            if (point == ECPoint.POINT_INFINITY) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
 
             var roots = new List<BigInteger>();
             Polynomial W = new Polynomial(1, 0, curve.a, curve.b);
@@ -426,7 +426,7 @@ namespace Eduard.Security.Extensions
                 throw new ArgumentException("Invalid Montgomery curve parameters.");
 
             /* map the point at infinity on a Montgomery curve to its equivalent on the Weierstrass curve */
-            if (point == ECPoint.POINT_INFINITY) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
             BigInteger Bt = BarrettReducer.MultMod(3, curve.B);
             BigInteger B3_inv = BarrettReducer.InvMod(Bt);
 
@@ -545,7 +545,7 @@ namespace Eduard.Security.Extensions
                 throw new ArgumentException("Invalid twisted Edwards curve parameters.");
 
             /* map the point at infinity on a twisted Edwards curve to its equivalent on the Weierstrass curve */
-            if (point.GetAffineX() == 0 && point.GetAffineY() == 1) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
 
             if (point.GetAffineX() == 0 || point.GetAffineY() == 1)
                 throw new ArgumentException("Exceptional point has no Weierstrass equivalent.");
@@ -656,7 +656,7 @@ namespace Eduard.Security.Extensions
                 throw new ArgumentException("Invalid Montgomery curve parameters.");
 
             /* map the point at infinity on a Montgomery curve to its equivalent on the twisted Edwards curve */
-            if (point == ECPoint.POINT_INFINITY) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
 
             if (point.GetAffineX() == 0 || point.GetAffineY() == curve.field - 1)
                 throw new ArgumentException("Exceptional point has no twisted Edwards equivalent.");
@@ -737,7 +737,7 @@ namespace Eduard.Security.Extensions
                 throw new ArgumentException("Invalid twisted Edwards curve parameters.");
 
             /* map the point at infinity on a twisted Edwards curve to its equivalent on the Montgomery curve */
-            if (point.GetAffineX() == 0 && point.GetAffineY() == 1) return ECPoint.POINT_INFINITY;
+            if (!point.isOnCurve) return ECPoint.POINT_INFINITY;
 
             if (point.GetAffineX() == 0 || point.GetAffineY() == 1)
                 throw new ArgumentException("Exceptional point has no Montgomery equivalent.");

--- a/Eduard/Security/Extensions/PointEncodingExtensions.cs
+++ b/Eduard/Security/Extensions/PointEncodingExtensions.cs
@@ -37,7 +37,7 @@ namespace Eduard.Security.Extensions
                     nameof(curve), "The elliptic " + 
                     "curve instance cannot be null.");
 
-            if (point == ECPoint.POINT_INFINITY)
+            if (!point.isOnCurve)
                 throw new ArgumentException(
                     "The point at infinity cannot be compressed "
                     + "or encoded in affine coordinates.",
@@ -99,7 +99,7 @@ namespace Eduard.Security.Extensions
                     "The Twisted Edwards curve instance " + 
                     "cannot be null.");
 
-            if (point == ECPoint.POINT_INFINITY)
+            if (!point.isOnCurve)
                 throw new ArgumentException("The point at " 
                     + "infinity cannot be compressed or " + 
                     "encoded in affine coordinates.", 

--- a/Eduard/Security/Extensions/SafeCurveExtensions.cs
+++ b/Eduard/Security/Extensions/SafeCurveExtensions.cs
@@ -63,7 +63,7 @@ namespace Eduard.Security.Extensions
 
             result = curve.ToAffine(auxPoint);
 
-            return (result != ECPoint.POINT_INFINITY) 
+            return result.isOnCurve 
                 ? PointCheck.EC_VALID : 
                 PointCheck.EC_SMALL_SUBGROUP;
         }
@@ -119,7 +119,7 @@ namespace Eduard.Security.Extensions
 
             result = curve.ToAffine(auxPoint);
 
-            return (result != ECPoint.POINT_INFINITY) 
+            return result.isOnCurve 
                 ? PointCheck.EC_VALID : 
                 PointCheck.EC_SMALL_SUBGROUP;
         }

--- a/Eduard/Security/PolyMod.cs
+++ b/Eduard/Security/PolyMod.cs
@@ -239,7 +239,7 @@ namespace Eduard.Security
                         y[j] = table[j].GetCoeff(L);
                     }
 
-                    t = DotMult(x, y);
+                    t = BarrettReducer.DotMult(x, y);
                     Q.coeffs[L] = t;
                 }
 
@@ -250,20 +250,6 @@ namespace Eduard.Security
             }
 
             return C;
-        }
-
-        private static BigInteger DotMult(BigInteger[] x, BigInteger[] y)
-        {
-            BigInteger res = 0;
-            int i, n = x.Length;
-
-            for (i = 0; i < n; i++)
-            {
-                BigInteger temp = BarrettReducer.MultMod(x[i], y[i]);
-                res = BarrettReducer.AddMod(res, temp);
-            }
-
-            return res;
         }
 
         /// <summary>

--- a/Eduard/Security/Primitives/ECPoint.cs
+++ b/Eduard/Security/Primitives/ECPoint.cs
@@ -10,7 +10,8 @@ namespace Eduard.Security.Primitives
     /// This struct encapsulates an affine point on an elliptic curve over a prime field. <br/>
     /// Points can be either ordinary curve points satisfying the curve equation, or the <br/>
     /// point at infinity which serves as the identity element in the elliptic curve group. <br/>
-    /// The point at infinity is represented with coordinates (0,1) and the isInfinity flag set.
+    /// The point at infinity is represented with isOnCurve set to false; its coordinates <br/>
+    /// are normalized to (0,1) via the accessor methods.
     /// </remarks>
 #if !USE_PROFILER
     [DebuggerStepThrough]
@@ -19,7 +20,7 @@ namespace Eduard.Security.Primitives
     {
         internal BigInteger x;
         internal BigInteger y;
-        internal bool isInfinity;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new elliptic curve point with the specified affine coordinates.
@@ -27,21 +28,21 @@ namespace Eduard.Security.Primitives
         /// <param name="x">The affine x-coordinate (must satisfy the curve equation).</param>
         /// <param name="y">The affine y-coordinate (must satisfy the curve equation).</param>
         /// <exception cref="ArgumentNullException">Thrown when x or y is null.</exception>
-        public ECPoint(BigInteger x, BigInteger y) : this(x, y, false)
+        public ECPoint(BigInteger x, BigInteger y) : this(x, y, true)
         { }
 
         /// <summary>
-        /// Initializes a new elliptic curve point with the specified affine coordinates and infinity flag.
+        /// Initializes a new elliptic curve point with the specified affine coordinates and curve membership flag.
         /// </summary>
         /// <param name="x">The affine x-coordinate.</param>
         /// <param name="y">The affine y-coordinate.</param>
-        /// <param name="isInfinity">Indicates whether this point represents the point at infinity.</param>
+        /// <param name="isOnCurve">Whether this point lies on the curve. Set to false for the point at infinity.</param>
         /// <exception cref="ArgumentNullException">Thrown when x or y is null.</exception>
         /// <remarks>
-        /// For the point at infinity, the coordinates are conventionally set to (0,1) with the <br/>
-        /// infinity flag set to true. The curve equation is not enforced for the point at infinity.
+        /// For the point at infinity, use <see cref="POINT_INFINITY"/> or pass isOnCurve = false. <br/>
+        /// The curve equation is not enforced for points with isOnCurve set to false.
         /// </remarks>
-        public ECPoint(BigInteger x, BigInteger y, bool isInfinity)
+        public ECPoint(BigInteger x, BigInteger y, bool isOnCurve)
         {
             if (ReferenceEquals(x, null))
                 throw new ArgumentNullException(nameof(x), 
@@ -51,7 +52,7 @@ namespace Eduard.Security.Primitives
                 throw new ArgumentNullException(nameof(y), 
                     "The affine y-coordinate cannot be null.");
 
-            this.isInfinity = isInfinity;
+            this.isOnCurve = isOnCurve;
             this.x = x; this.y = y;
         }
 
@@ -59,13 +60,13 @@ namespace Eduard.Security.Primitives
         /// Gets the point at infinity (additive identity) for elliptic curve groups.
         /// </summary>
         /// <remarks>
-        /// The point at infinity is represented with coordinates (0,1) and the infinity flag set to true.
+        /// Represented with isOnCurve = false, normalized to (0,1) by the accessor methods.
         /// </remarks>
         public static ECPoint POINT_INFINITY
         {
             get
             {
-                var infinity = new ECPoint(0, 1, true);
+                var infinity = new ECPoint(0, 1, false);
                 return infinity;
             }
         }
@@ -73,37 +74,42 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// Gets the affine x-coordinate of this point.
         /// </summary>
-        /// <returns>The x-coordinate as a BigInteger.</returns>
+        /// <returns>The x-coordinate as a BigInteger, or 0 for the point at infinity.</returns>
         public BigInteger GetAffineX()
         {
-            return x;
+            return isOnCurve ? x : 0;
         }
 
         /// <summary>
         /// Gets the affine y-coordinate of this point.
         /// </summary>
-        /// <returns>The y-coordinate as a BigInteger.</returns>
+        /// <returns>The y-coordinate as a BigInteger, or 1 for the point at infinity.</returns>
         public BigInteger GetAffineY()
         {
-            return y;
+            return isOnCurve ? y : 1;
         }
 
         /// <summary>
         /// Indicates whether the current point is equal to another point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points have identical affine coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the points have identical normalized affine coordinates; otherwise <c>false</c>.</returns>
         /// <remarks>
-        /// Two points are considered equal if they have the same x and y <br/> coordinates.
-        /// The point at infinity (0,1,true) is only equal to itself.
+        /// Equality is determined on normalized coordinates. The point at infinity is only equal to itself.
         /// </remarks>
         public bool Equals(ECPoint other)
         {
-            if (isInfinity != other.isInfinity)
+            if (isOnCurve != other.isOnCurve)
                 return false;
 
-            bool sameXCoord = x == other.x;
-            bool sameYCoord = y == other.y;
+            BigInteger tx = isOnCurve ? x : 0;
+            BigInteger ty = isOnCurve ? y : 1;
+
+            BigInteger ox = other.isOnCurve ? other.x : 0;
+            BigInteger oy = other.isOnCurve ? other.y : 1;
+
+            bool sameXCoord = tx == ox;
+            bool sameYCoord = ty == oy;
             return sameXCoord && sameYCoord;
         }
 
@@ -111,7 +117,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint with identical normalized coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint))
@@ -126,7 +132,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points have identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the points have identical coordinates; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint left, ECPoint right)
         {
             return left.Equals(right);
@@ -137,7 +143,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points have different coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the points have different coordinates; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint left, ECPoint right)
         {
             return !left.Equals(right);
@@ -148,14 +154,16 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <returns>A 32-bit signed integer hash code.</returns>
         /// <remarks>
-        /// The hash code is computed by XORing the hash codes of the x and y coordinates. <br/>
-        /// This ensures that points with identical coordinates produce the same hash code, <br/>
-        /// maintaining consistency with the equality semantics of the struct.
+        /// The point at infinity returns a hash code of 0. For affine points, the hash code <br/>
+        /// is computed by XORing the hash codes of the x and y coordinates. This ensures that <br/>
+        /// points with identical coordinates produce the same hash code, maintaining consistency <br/>
+        /// with the equality semantics of the struct.
         /// </remarks>
         public override int GetHashCode()
         {
             unchecked
             {
+                if (!isOnCurve) return 0;
                 int xHash = x.GetHashCode();
                 int yHash = y.GetHashCode();
                 return xHash ^ yHash;

--- a/Eduard/Security/Primitives/ECPoint.cs
+++ b/Eduard/Security/Primitives/ECPoint.cs
@@ -111,17 +111,17 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint other)
         {
-            if (isOnCurve != other.isOnCurve)
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
+
+            if (isInfinitySelf != isInfinityOther)
                 return false;
 
-            BigInteger tx = isOnCurve ? x : 0;
-            BigInteger ty = isOnCurve ? y : 1;
+            if (isInfinitySelf && isInfinityOther)
+                return true;
 
-            BigInteger ox = other.isOnCurve ? other.x : 0;
-            BigInteger oy = other.isOnCurve ? other.y : 1;
-
-            bool sameXCoord = tx == ox;
-            bool sameYCoord = ty == oy;
+            bool sameXCoord = x == other.x;
+            bool sameYCoord = y == other.y;
             return sameXCoord && sameYCoord;
         }
 

--- a/Eduard/Security/Primitives/ECPoint.cs
+++ b/Eduard/Security/Primitives/ECPoint.cs
@@ -57,6 +57,18 @@ namespace Eduard.Security.Primitives
         }
 
         /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if the point is at infinity; otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
+        }
+
+        /// <summary>
         /// Gets the point at infinity (additive identity) for elliptic curve groups.
         /// </summary>
         /// <remarks>

--- a/Eduard/Security/Primitives/ECPoint3.cs
+++ b/Eduard/Security/Primitives/ECPoint3.cs
@@ -109,7 +109,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint3 left, ECPoint3 right)
         {
             return left.Equals(right);
@@ -120,7 +120,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent different geometric points; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent different geometric points; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint3 left, ECPoint3 right)
         {
             return !left.Equals(right);
@@ -151,7 +151,7 @@ namespace Eduard.Security.Primitives
         /// Indicates whether the current point is equal to another projective point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Two points are considered equal if:
         /// <list type="bullet">
@@ -182,7 +182,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current projective point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint3 with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint3 with identical coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint3))

--- a/Eduard/Security/Primitives/ECPoint3.cs
+++ b/Eduard/Security/Primitives/ECPoint3.cs
@@ -21,12 +21,18 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// The projective X-coordinate.
         /// </summary>
-        public BigInteger x;
+        public BigInteger X
+        {
+            get { return isOnCurve ? x : 0; }
+        }
 
         /// <summary>
         /// The projective Y-coordinate.
         /// </summary>
-        public BigInteger y;
+        public BigInteger Y
+        {
+            get { return isOnCurve ? y : 1; }
+        }
 
         /// <summary>
         /// The projective Z-coordinate.
@@ -35,7 +41,13 @@ namespace Eduard.Security.Primitives
         /// Z = 0 indicates the point at infinity. <br/>
         /// For finite points, Z is non-zero.
         /// </remarks>
-        public BigInteger z;
+        public BigInteger Z
+        {
+            get { return isOnCurve ? z : 0; }
+        }
+
+        internal BigInteger x, y, z;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new projective point with the specified coordinates.
@@ -58,9 +70,21 @@ namespace Eduard.Security.Primitives
                 throw new ArgumentNullException(nameof(z),
                     "The projective Z-coordinate cannot be null.");
 
-            this.x = x;
-            this.y = y;
+            this.x = x; this.y = y;
+            isOnCurve = z != 0;
             this.z = z;
+        }
+
+        /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if the point is at infinity (Z = 0); otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
         }
 
         /// <summary>
@@ -114,7 +138,7 @@ namespace Eduard.Security.Primitives
         {
             unchecked
             {
-                if (z == 0) return 0;
+                if (!isOnCurve) return 0;
                 int xHash = x.GetHashCode();
                 int yHash = y.GetHashCode();
 
@@ -137,8 +161,8 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint3 other)
         {
-            bool isInfinitySelf = z == 0;
-            bool isInfinityOther = other.z == 0;
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
 
             if (isInfinitySelf != isInfinityOther)
                 return false;

--- a/Eduard/Security/Primitives/ECPoint3w.cs
+++ b/Eduard/Security/Primitives/ECPoint3w.cs
@@ -114,7 +114,7 @@ namespace Eduard.Security.Primitives
         /// Indicates whether the current point is equal to another Jacobian point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Two points are considered equal if:
         /// <list type="bullet">
@@ -145,7 +145,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current Jacobian point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint3w with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint3w with identical coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint3w))
@@ -160,7 +160,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points have identical projective coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the points have identical projective coordinates; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint3w left, ECPoint3w right)
         {
             return left.Equals(right);
@@ -171,7 +171,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points have different projective coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the points have different projective coordinates; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint3w left, ECPoint3w right)
         {
             return !left.Equals(right);

--- a/Eduard/Security/Primitives/ECPoint3w.cs
+++ b/Eduard/Security/Primitives/ECPoint3w.cs
@@ -53,7 +53,7 @@ namespace Eduard.Security.Primitives
             get { return isOnCurve ? z : 0; }
         }
 
-        private BigInteger x, y, z;
+        internal BigInteger x, y, z;
         internal bool isOnCurve;
 
         /// <summary>

--- a/Eduard/Security/Primitives/ECPoint3w.cs
+++ b/Eduard/Security/Primitives/ECPoint3w.cs
@@ -28,12 +28,18 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// The X-coordinate in Jacobian projective representation.
         /// </summary>
-        public BigInteger x;
+        public BigInteger X
+        {
+            get { return isOnCurve ? x : 1; }
+        }
 
         /// <summary>
         /// The Y-coordinate in Jacobian projective representation.
         /// </summary>
-        public BigInteger y;
+        public BigInteger Y
+        {
+            get { return isOnCurve ? y : 1; }
+        }
 
         /// <summary>
         /// The Z-coordinate in Jacobian projective representation.
@@ -42,7 +48,12 @@ namespace Eduard.Security.Primitives
         /// Z = 0 indicates the point at infinity. Otherwise, Z is non-zero <br/> and typically
         /// normalized to 1 for affine points after conversion.
         /// </remarks>
-        public BigInteger z;
+        public BigInteger Z
+        {
+            get { return isOnCurve ? z : 0; }
+        }
+
+        private BigInteger x, y, z;
         internal bool isOnCurve;
 
         /// <summary>

--- a/Eduard/Security/Primitives/ECPoint3w.cs
+++ b/Eduard/Security/Primitives/ECPoint3w.cs
@@ -43,6 +43,7 @@ namespace Eduard.Security.Primitives
         /// normalized to 1 for affine points after conversion.
         /// </remarks>
         public BigInteger z;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new Jacobian projective point with the specified coordinates.
@@ -65,9 +66,21 @@ namespace Eduard.Security.Primitives
                 throw new ArgumentNullException(nameof(z),
                     "The projective Z-coordinate cannot be null.");
 
-            this.x = x;
-            this.y = y;
+            this.x = x; this.y = y;
+            isOnCurve = z != 0;
             this.z = z;
+        }
+
+        /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if the point is at infinity (Z = 0); otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
         }
 
         /// <summary>
@@ -100,8 +113,8 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint3w other)
         {
-            bool isInfinitySelf = z == 0;
-            bool isInfinityOther = other.z == 0;
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
 
             if (isInfinitySelf != isInfinityOther)
                 return false;
@@ -165,7 +178,7 @@ namespace Eduard.Security.Primitives
         {
             unchecked
             {
-                if (z == 0) return 0;
+                if (!isOnCurve) return 0;
                 int xHash = x.GetHashCode();
                 int yHash = y.GetHashCode();
 

--- a/Eduard/Security/Primitives/ECPoint4.cs
+++ b/Eduard/Security/Primitives/ECPoint4.cs
@@ -22,12 +22,18 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// The projective X-coordinate.
         /// </summary>
-        public BigInteger x;
+        public BigInteger X
+        {
+            get { return isOnCurve ? x : 0; }
+        }
 
         /// <summary>
         /// The projective Y-coordinate.
         /// </summary>
-        public BigInteger y;
+        public BigInteger Y
+        {
+            get { return isOnCurve ? y : 1; }
+        }
 
         /// <summary>
         /// The projective T-coordinate, where T = (X*Y)/Z.
@@ -36,7 +42,10 @@ namespace Eduard.Security.Primitives
         /// This coordinate caches the product (X*Y)/Z to optimize point <br/>
         /// addition. For the point at infinity, T must be 0 when Z = 0.
         /// </remarks>
-        public BigInteger t;
+        public BigInteger T
+        {
+            get { return isOnCurve ? t : 0; }
+        }
 
         /// <summary>
         /// The projective Z-coordinate.
@@ -45,7 +54,13 @@ namespace Eduard.Security.Primitives
         /// Z = 0 indicates the point at infinity. <br/>
         /// For finite points, Z is non-zero.
         /// </remarks>
-        public BigInteger z;
+        public BigInteger Z
+        {
+            get { return isOnCurve ? z : 0; }
+        }
+
+        internal BigInteger x, y, t, z;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new extended projective point with the specified coordinates.
@@ -83,6 +98,19 @@ namespace Eduard.Security.Primitives
 
             this.x = x; this.y = y;
             this.t = t; this.z = z;
+            isOnCurve = z != 0;
+        }
+
+        /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if the point is at infinity (Z = 0 and T = 0); otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
         }
 
         /// <summary>
@@ -107,7 +135,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint4 left, ECPoint4 right)
         {
             return left.Equals(right);
@@ -118,7 +146,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent different geometric points; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent different geometric points; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint4 left, ECPoint4 right)
         {
             return !left.Equals(right);
@@ -138,7 +166,7 @@ namespace Eduard.Security.Primitives
             unchecked
             {
                 /* all points at infinity share the same hash */
-                if (z == 0 && t == 0) return 0;
+                if (!isOnCurve) return 0;
 
                 /* combine all coordinates */
                 int xHash = x.GetHashCode();
@@ -157,10 +185,7 @@ namespace Eduard.Security.Primitives
         /// Indicates whether the current point is equal to another extended projective point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if either point violates the invariant (Z = 0 but T != 0).
-        /// </exception>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Two points are considered equal if:
         /// <list type="bullet">
@@ -172,16 +197,8 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint4 other)
         {
-            bool isInfinitySelf = z == 0;
-            bool isInfinityOther = other.z == 0;
-
-            if (isInfinitySelf && t != 0)
-                throw new InvalidOperationException(
-                    "Current point at infinity has non-zero T coordinate.");
-
-            if (isInfinityOther && other.t != 0)
-                throw new InvalidOperationException(
-                    "Other point at infinity has non-zero T coordinate.");
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
 
             if (isInfinitySelf != isInfinityOther)
                 return false;
@@ -199,7 +216,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current extended projective point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint4 with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint4 with identical coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint4))

--- a/Eduard/Security/Primitives/ECPoint4w.cs
+++ b/Eduard/Security/Primitives/ECPoint4w.cs
@@ -33,12 +33,18 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// The X-coordinate in modified Jacobian representation.
         /// </summary>
-        public BigInteger x;
+        public BigInteger X 
+        { 
+            get { return isOnCurve ? x : 1; } 
+        }
 
         /// <summary>
         /// The Y-coordinate in modified Jacobian representation.
         /// </summary>
-        public BigInteger y;
+        public BigInteger Y 
+        { 
+            get { return isOnCurve ? y : 1; } 
+        }
 
         /// <summary>
         /// The Z-coordinate in modified Jacobian representation.
@@ -46,7 +52,10 @@ namespace Eduard.Security.Primitives
         /// <remarks>
         /// Z = 0 indicates the point at infinity. For finite points, Z is non-zero.
         /// </remarks>
-        public BigInteger z;
+        public BigInteger Z 
+        { 
+            get { return isOnCurve ? z : 0; } 
+        }
 
         /// <summary>
         /// The pre-computed value aZ^4 where 'a' is the Weierstrass curve parameter.
@@ -55,7 +64,14 @@ namespace Eduard.Security.Primitives
         /// This cached value eliminates redundant computations in point doubling.<br/>
         /// For the point at infinity, this must be 0 to maintain consistency.
         /// </remarks>
-        public BigInteger aZ4;
+        public BigInteger aZ4
+        {
+            get { return isOnCurve ? az4 : 0; }
+        }
+
+        private BigInteger x, y;
+        private BigInteger z, az4;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new modified Jacobian point with the specified coordinates.
@@ -94,7 +110,21 @@ namespace Eduard.Security.Primitives
             this.x = x;
             this.y = y;
             this.z = z;
-            this.aZ4 = aZ4;
+
+            isOnCurve = z != 0;
+            this.az4 = aZ4;
+        }
+
+        /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if Z = 0 and aZ^4 = 0; otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
         }
 
         /// <summary>
@@ -131,16 +161,8 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint4w other)
         {
-            bool isInfinitySelf = z == 0;
-            bool isInfinityOther = other.z == 0;
-
-            if (isInfinitySelf && aZ4 != 0)
-                throw new InvalidOperationException(
-                    "Current point at infinity has non-zero aZ^4.");
-
-            if (isInfinityOther && other.aZ4 != 0)
-                throw new InvalidOperationException(
-                    "Other point at infinity has non-zero aZ^4.");
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
 
             if (isInfinitySelf != isInfinityOther)
                 return false;
@@ -150,7 +172,7 @@ namespace Eduard.Security.Primitives
 
             /* compare all coordinates */
             return x == other.x && y == other.y &&
-                   z == other.z && aZ4 == other.aZ4;
+                   z == other.z && az4 == other.az4;
         }
 
         /// <summary>
@@ -201,15 +223,14 @@ namespace Eduard.Security.Primitives
         {
             unchecked
             {
-                if (z == 0 && aZ4 == 0)
-                    return 0;
-
+                if (!isOnCurve) return 0;
                 int hash = 17;
+
                 hash = hash * 31 + x.GetHashCode();
                 hash = hash * 31 + y.GetHashCode();
 
                 hash = hash * 31 + z.GetHashCode();
-                hash = hash * 31 + aZ4.GetHashCode();
+                hash = hash * 31 + az4.GetHashCode();
                 return hash;
             }
         }

--- a/Eduard/Security/Primitives/ECPoint4w.cs
+++ b/Eduard/Security/Primitives/ECPoint4w.cs
@@ -148,10 +148,7 @@ namespace Eduard.Security.Primitives
         /// Indicates whether the current point is equal to another modified Jacobian point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if either point violates the invariant (Z=0 but aZ^4 != 0).
-        /// </exception>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Two points are considered equal if:
         /// <list type="bullet">
@@ -179,7 +176,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current modified Jacobian point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint4w with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint4w with identical coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint4w))
@@ -194,7 +191,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint4w left, ECPoint4w right)
         {
             return left.Equals(right);
@@ -205,7 +202,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent different geometric points; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent different geometric points; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint4w left, ECPoint4w right)
         {
             return !left.Equals(right);

--- a/Eduard/Security/Primitives/ECPoint4w.cs
+++ b/Eduard/Security/Primitives/ECPoint4w.cs
@@ -69,8 +69,8 @@ namespace Eduard.Security.Primitives
             get { return isOnCurve ? az4 : 0; }
         }
 
-        private BigInteger x, y;
-        private BigInteger z, az4;
+        internal BigInteger x, y;
+        internal BigInteger z, az4;
         internal bool isOnCurve;
 
         /// <summary>

--- a/Eduard/Security/Primitives/ECPoint5w.cs
+++ b/Eduard/Security/Primitives/ECPoint5w.cs
@@ -35,12 +35,18 @@ namespace Eduard.Security.Primitives
         /// <summary>
         /// The X-coordinate in Jacobian-Chudnovsky representation.
         /// </summary>
-        public BigInteger x;
+        public BigInteger X
+        {
+            get { return isOnCurve ? x : 1; }
+        }
 
         /// <summary>
         /// The Y-coordinate in Jacobian-Chudnovsky representation.
         /// </summary>
-        public BigInteger y;
+        public BigInteger Y
+        {
+            get { return isOnCurve ? y : 1; }
+        }
 
         /// <summary>
         /// The Z-coordinate in Jacobian-Chudnovsky representation.
@@ -48,7 +54,10 @@ namespace Eduard.Security.Primitives
         /// <remarks>
         /// Z = 0 indicates the point at infinity. For finite points, Z is non-zero.
         /// </remarks>
-        public BigInteger z;
+        public BigInteger Z
+        {
+            get { return isOnCurve ? z : 0; }
+        }
 
         /// <summary>
         /// The pre-computed value Z^2.
@@ -57,7 +66,10 @@ namespace Eduard.Security.Primitives
         /// This cached value eliminates redundant squaring operations.<br/>
         /// Must satisfy z2 = z * z (mod p) for finite points.
         /// </remarks>
-        public BigInteger z2;
+        public BigInteger Z2
+        {
+            get { return isOnCurve ? z2 : 0; }
+        }
 
         /// <summary>
         /// The pre-computed value Z^3.
@@ -66,7 +78,14 @@ namespace Eduard.Security.Primitives
         /// This cached value eliminates redundant cubing operations.<br/>
         /// Must satisfy z3 = z * z * z (mod p) for finite points.
         /// </remarks>
-        public BigInteger z3;
+        public BigInteger Z3
+        {
+            get { return isOnCurve ? z3 : 0; }
+        }
+
+        internal BigInteger x, y, z;
+        internal BigInteger z2, z3;
+        internal bool isOnCurve;
 
         /// <summary>
         /// Initializes a new Jacobian-Chudnovsky point with the specified coordinates.
@@ -111,8 +130,21 @@ namespace Eduard.Security.Primitives
             this.y = y;
             this.z = z;
 
+            isOnCurve = z != 0;
             this.z2 = z2;
             this.z3 = z3;
+        }
+
+        /// <summary>
+        /// Gets whether this point is the point at infinity.
+        /// </summary>
+        /// <returns><c>true</c> if Z = 0, Z^2 = 0, Z^3 = 0; otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// The point at infinity serves as the identity element in the elliptic curve group.
+        /// </remarks>
+        public bool IsInfinity
+        {
+            get { return !isOnCurve; }
         }
 
         /// <summary>
@@ -136,10 +168,7 @@ namespace Eduard.Security.Primitives
         /// Indicates whether the current point is equal to another Jacobian-Chudnovsky point.
         /// </summary>
         /// <param name="other">The point to compare with this point.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if either point violates the invariant (Z=0 but Z^2 != 0 or Z^3 != 0).
-        /// </exception>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Two points are considered equal if:
         /// <list type="bullet">
@@ -149,17 +178,8 @@ namespace Eduard.Security.Primitives
         /// </remarks>
         public bool Equals(ECPoint5w other)
         {
-            bool isInfinitySelf = z == 0;
-            bool isInfinityOther = other.z == 0;
-
-            /* validate invariants */
-            if (isInfinitySelf && (z2 != 0 || z3 != 0))
-                throw new InvalidOperationException(
-                    "Current point at infinity has non-zero Z^2 or Z^3.");
-
-            if (isInfinityOther && (other.z2 != 0 || other.z3 != 0))
-                throw new InvalidOperationException(
-                    "Other point at infinity has non-zero Z^2 or Z^3.");
+            bool isInfinitySelf = !isOnCurve;
+            bool isInfinityOther = !other.isOnCurve;
 
             /* different infinity status */
             if (isInfinitySelf != isInfinityOther)
@@ -179,7 +199,7 @@ namespace Eduard.Security.Primitives
         /// Determines whether the specified object is equal to the current Jacobian-Chudnovsky point.
         /// </summary>
         /// <param name="obj">The object to compare with the current point.</param>
-        /// <returns>true if the object is an ECPoint5w with identical coordinates; otherwise false.</returns>
+        /// <returns><c>true</c> if the object is an ECPoint5w with identical coordinates; otherwise <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             if (!(obj is ECPoint5w))
@@ -193,7 +213,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent the same geometric point; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent the same geometric point; otherwise <c>false</c>.</returns>
         public static bool operator ==(ECPoint5w left, ECPoint5w right)
         {
             return left.Equals(right);
@@ -204,7 +224,7 @@ namespace Eduard.Security.Primitives
         /// </summary>
         /// <param name="left">The first point to compare.</param>
         /// <param name="right">The second point to compare.</param>
-        /// <returns>true if the points represent different geometric points; otherwise false.</returns>
+        /// <returns><c>true</c> if the points represent different geometric points; otherwise <c>false</c>.</returns>
         public static bool operator !=(ECPoint5w left, ECPoint5w right)
         {
             return !left.Equals(right);
@@ -223,8 +243,7 @@ namespace Eduard.Security.Primitives
             unchecked
             {
                 /* point at infinity: constant hash regardless of X,Y */
-                if (z == 0 && z2 == 0 && z3 == 0)
-                    return 0;
+                if (!isOnCurve) return 0;
 
                 /* for normal points, combine all coordinates */
                 int hash = 17;

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -172,19 +172,19 @@ namespace Eduard.Tests.Curves
         {
             /* normal point construction */
             var point1 = new ECPoint5w(10, 20, 3, 9, 27);
-            Assert.Equal(10, point1.x);
-            Assert.Equal(20, point1.y);
-            Assert.Equal(3, point1.z);
-            Assert.Equal(9, point1.z2);
-            Assert.Equal(27, point1.z3);
+            Assert.Equal(10, point1.X);
+            Assert.Equal(20, point1.Y);
+            Assert.Equal(3, point1.Z);
+            Assert.Equal(9, point1.Z2);
+            Assert.Equal(27, point1.Z3);
 
             /* point at infinity via static property */
             var infinity = ECPoint5w.POINT_INFINITY;
-            Assert.Equal(1, infinity.x);
-            Assert.Equal(1, infinity.y);
-            Assert.Equal(0, infinity.z);
-            Assert.Equal(0, infinity.z2);
-            Assert.Equal(0, infinity.z3);
+            Assert.Equal(1, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
+            Assert.Equal(0, infinity.Z2);
+            Assert.Equal(0, infinity.Z3);
 
             /* point at infinity with Z=0, Z2=0, Z3=0 (valid) */
             var infinityValid = new ECPoint5w(999, 888, 0, 0, 0);
@@ -227,12 +227,6 @@ namespace Eduard.Tests.Curves
             /* null comparison */
             Assert.False(point1.Equals(null));
             Assert.False(point1.Equals("not a point"));
-
-            /* invariant violation detection in Equals */
-            var invalidInfinity = new ECPoint5w(0, 0, 0, 0, 0);
-            invalidInfinity.z2 = 5;
-            Assert.Throws<InvalidOperationException>(() =>
-                invalidInfinity.Equals(infinity));
         }
 
         #endregion

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -238,15 +238,15 @@ namespace Eduard.Tests.Curves
         {
             /* normal point construction */
             var point1 = new ECPoint3(10, 20, 1);
-            Assert.Equal(10, point1.x);
-            Assert.Equal(20, point1.y);
-            Assert.Equal(1, point1.z);
+            Assert.Equal(10, point1.X);
+            Assert.Equal(20, point1.Y);
+            Assert.Equal(1, point1.Z);
 
             /* point at infinity via static property */
             var infinity = ECPoint3.POINT_INFINITY;
-            Assert.Equal(0, infinity.x);
-            Assert.Equal(1, infinity.y);
-            Assert.Equal(0, infinity.z);
+            Assert.Equal(0, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
 
             /* point at infinity with arbitrary coordinates (Z=0) */
             var infinityAlt = new ECPoint3(999, 888, 0);

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -1,354 +1,831 @@
-﻿using System;
-using Eduard.Security.Primitives;
+﻿using Eduard.Security.Primitives;
+using System;
+using System.Collections.Generic;
 
 namespace Eduard.Tests.Curves
 {
     public class PointTests
     {
-        #region Affine Point Tests (ECPoint)
+        #region Constructor Tests
 
         [Fact]
-        public void ECPoint_ConstructorAndEquality_HandlesAllCases()
+        public void Constructor_WithValidCoordinates_CreatesAffinePoint()
         {
-            /* normal point construction */
-            var point1 = new ECPoint(5, 7);
-            Assert.Equal(5, point1.GetAffineX());
-            Assert.Equal(7, point1.GetAffineY());
-            Assert.False(point1 == ECPoint.POINT_INFINITY);
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* point at infinity via static property */
+            var point = new ECPoint(x, y);
+
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.GetAffineX());
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        [Fact]
+        public void Constructor_WithValidCoordinates_IsNotInfinity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void Constructor_WithIsOnCurveFalse_CreatesInfinityPoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y, false);
+
+            Assert.False(!point.IsInfinity);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void Constructor_WithIsOnCurveTrue_CreatesFinitePoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y, true);
+
+            Assert.True(!point.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            var point = new ECPoint(x, y);
+
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.GetAffineX());
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        [Fact]
+        public void Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            var point = new ECPoint(x, y);
+
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.GetAffineX());
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        [Fact]
+        public void Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint(null, y));
+        }
+
+        [Fact]
+        public void Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint(x, null));
+        }
+
+        [Fact]
+        public void Constructor_WithNullXAndNullY_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint(null, null));
+        }
+
+        [Fact]
+        public void Constructor_WithNullXAndIsOnCurveFalse_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint(null, y, false));
+        }
+
+        [Fact]
+        public void Constructor_WithNullYAndIsOnCurveFalse_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint(x, null, false));
+        }
+
+        [Fact]
+        public void Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            var point = new ECPoint(x, y);
+
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.GetAffineX());
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void PointInfinity_NormalizedCoordinates_ReturnsZeroAndOne()
+        {
             var infinity = ECPoint.POINT_INFINITY;
             Assert.Equal(0, infinity.GetAffineX());
             Assert.Equal(1, infinity.GetAffineY());
+        }
 
-            /* point at infinity via constructor with flag */
-            var infinity2 = new ECPoint(0, 1, false);
-            Assert.Equal(infinity, infinity2);
+        [Fact]
+        public void PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint.POINT_INFINITY;
+            var infinity2 = ECPoint.POINT_INFINITY;
 
-            /* equality: same coordinates */
-            var point2 = new ECPoint(5, 7);
-            Assert.Equal(point1, point2);
-            Assert.True(point1 == point2);
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
 
-            /* inequality: different coordinates */
-            var point3 = new ECPoint(5, 8);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
+        [Fact]
+        public void PointInfinity_InternalCoordinatesNormalized_RegardlessOfInput()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
 
-            /* inequality: infinity vs finite */
-            Assert.NotEqual(infinity, point1);
-            Assert.True(infinity != point1);
+            var notOnCurve = new ECPoint(x, y, false);
+            Assert.Equal(0, notOnCurve.GetAffineX());
+            Assert.Equal(1, notOnCurve.GetAffineY());
+        }
 
-            /* hash code consistency */
-            Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
-            Assert.Equal(infinity.GetHashCode(), infinity2.GetHashCode());
-
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+        [Fact]
+        public void DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint);
+            Assert.True(defaultPoint.IsInfinity);
+            Assert.Equal(0, defaultPoint.GetAffineX());
+            Assert.Equal(1, defaultPoint.GetAffineY());
         }
 
         #endregion
 
-        #region Weierstrass Jacobian Tests (ECPoint3w)
+        #region Coordinate Accessor Tests
 
         [Fact]
-        public void ECPoint3w_ConstructorAndEquality_HandlesAllCases()
+        public void GetAffineX_FinitePoint_ReturnsStoredValue()
         {
-            /* normal point construction */
-            var point1 = new ECPoint3w(10, 20, 1);
-            Assert.Equal(10, point1.X);
-            Assert.Equal(20, point1.Y);
-            Assert.Equal(1, point1.Z);
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* point at infinity via static property */
-            var infinity = ECPoint3w.POINT_INFINITY;
-            Assert.Equal(1, infinity.X);
-            Assert.Equal(1, infinity.Y);
-            Assert.Equal(0, infinity.Z);
+            var point = new ECPoint(x, y);
+            Assert.Equal(x, point.GetAffineX());
+        }
 
-            /* point at infinity with arbitrary coordinates (Z=0) */
-            var infinityAlt = new ECPoint3w(999, 888, 0);
-            Assert.Equal(infinity, infinityAlt);
+        [Fact]
+        public void GetAffineX_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetAffineX());
+        }
 
-            /* equality: same coordinates */
-            var point2 = new ECPoint3w(10, 20, 1);
-            Assert.Equal(point1, point2);
-            Assert.True(point1 == point2);
+        [Fact]
+        public void GetAffineX_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
 
-            /* equality: both infinity (different X,Y but Z=0) */
-            Assert.Equal(infinity, infinityAlt);
-            Assert.True(infinity == infinityAlt);
+            var point = new ECPoint(x, y, false);
+            Assert.Equal(0, point.GetAffineX());
+        }
 
-            /* inequality: different coordinates */
-            var point3 = new ECPoint3w(10, 21, 1);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
+        [Fact]
+        public void GetAffineX_WithZeroCoordinate_ReturnsZero()
+        {
+            BigInteger x = 0;
+            BigInteger y = 10;
 
-            /* inequality: finite vs infinity */
-            Assert.NotEqual(point1, infinity);
-            Assert.True(point1 != infinity);
+            var point = new ECPoint(x, y);
+            Assert.Equal(0, point.GetAffineX());
+        }
 
-            /* hash code: finite points hash based on coordinates */
-            Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
+        [Fact]
+        public void GetAffineX_WithNegativeCoordinate_ReturnsNegative()
+        {
+            BigInteger x = -1;
+            BigInteger y = 10;
 
-            /* hash code: all infinity points hash to same value */
-            Assert.Equal(infinity.GetHashCode(), infinityAlt.GetHashCode());
-            Assert.Equal(0, infinity.GetHashCode());
+            var point = new ECPoint(x, y);
+            Assert.Equal(x, point.GetAffineX());
+        }
 
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+        [Fact]
+        public void GetAffineX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            var point = new ECPoint(x, y);
+            var result1 = point.GetAffineX();
+
+            var result2 = point.GetAffineX();
+            var result3 = point.GetAffineX();
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void GetAffineY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        [Fact]
+        public void GetAffineY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint.POINT_INFINITY;
+            Assert.Equal(1, infinity.GetAffineY());
+        }
+
+        [Fact]
+        public void GetAffineY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            var point = new ECPoint(x, y, false);
+            Assert.Equal(1, point.GetAffineY());
+        }
+
+        [Fact]
+        public void GetAffineY_WithZeroCoordinate_ReturnsZero()
+        {
+            BigInteger x = 5;
+            BigInteger y = 0;
+
+            var point = new ECPoint(x, y);
+            Assert.Equal(0, point.GetAffineY());
+        }
+
+        [Fact]
+        public void GetAffineY_WithNegativeCoordinate_ReturnsNegative()
+        {
+            BigInteger x = 5;
+            BigInteger y = -1;
+
+            var point = new ECPoint(x, y);
+            Assert.Equal(y, point.GetAffineY());
+        }
+
+        [Fact]
+        public void GetAffineY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            var point = new ECPoint(x, y);
+            var result1 = point.GetAffineY();
+
+            var result2 = point.GetAffineY();
+            var result3 = point.GetAffineY();
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
         }
 
         #endregion
 
-        #region Weierstrass Modified Jacobian Tests (ECPoint4w)
+        #region Point Validity Tests
 
         [Fact]
-        public void ECPoint4w_ConstructorAndEquality_HandlesAllCases()
+        public void IsInfinity_FinitePoint_ReturnsFalse()
         {
-            /* normal point construction */
-            var point1 = new ECPoint4w(10, 20, 5, 100);
-            Assert.Equal(10, point1.X);
-            Assert.Equal(20, point1.Y);
-            Assert.Equal(5, point1.Z);
-            Assert.Equal(100, point1.aZ4);
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* point at infinity via static property */
-            var infinity = ECPoint4w.POINT_INFINITY;
-            Assert.Equal(1, infinity.X);
-            Assert.Equal(1, infinity.Y);
-            Assert.Equal(0, infinity.Z);
-            Assert.Equal(0, infinity.aZ4);
+            var point = new ECPoint(x, y);
+            Assert.False(point.IsInfinity);
+        }
 
-            /* point at infinity with Z=0 and aZ4=0 (valid) */
-            var infinityValid = new ECPoint4w(999, 888, 0, 0);
-            Assert.Equal(infinity, infinityValid);
+        [Fact]
+        public void IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            var point = new ECPoint(5, 10, false);
+            Assert.True(point.IsInfinity);
+        }
 
-            /* invalid: point at infinity with non-zero aZ4 */
-            Assert.Throws<InvalidOperationException>(() =>
-                new ECPoint4w(1, 1, 0, 5));
-
-            /* equality: same coordinates */
-            var point2 = new ECPoint4w(10, 20, 5, 100);
-            Assert.Equal(point1, point2);
-            Assert.True(point1 == point2);
-
-            /* equality: both infinity (valid representations) */
-            Assert.Equal(infinity, infinityValid);
-            Assert.True(infinity == infinityValid);
-
-            /* inequality: different coordinates */
-            var point3 = new ECPoint4w(10, 21, 5, 100);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
-
-            /* inequality: finite vs infinity */
-            Assert.NotEqual(point1, infinity);
-            Assert.True(point1 != infinity);
-
-            /* hash code: finite points hash based on coordinates */
-            Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
-
-            /* hash code: all infinity points hash to same value */
-            Assert.Equal(infinity.GetHashCode(), infinityValid.GetHashCode());
-            Assert.Equal(0, infinity.GetHashCode());
-
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+        [Fact]
+        public void IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint.POINT_INFINITY.IsInfinity);
         }
 
         #endregion
 
-        #region Weierstrass Jacobian-Chudnovsky Tests (ECPoint5w)
+        #region Equality Tests
 
         [Fact]
-        public void ECPoint5w_ConstructorAndEquality_HandlesAllCases()
+        public void Equals_SameCoordinates_ReturnsTrue()
         {
-            /* normal point construction */
-            var point1 = new ECPoint5w(10, 20, 3, 9, 27);
-            Assert.Equal(10, point1.X);
-            Assert.Equal(20, point1.Y);
-            Assert.Equal(3, point1.Z);
-            Assert.Equal(9, point1.Z2);
-            Assert.Equal(27, point1.Z3);
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* point at infinity via static property */
-            var infinity = ECPoint5w.POINT_INFINITY;
-            Assert.Equal(1, infinity.X);
-            Assert.Equal(1, infinity.Y);
-            Assert.Equal(0, infinity.Z);
-            Assert.Equal(0, infinity.Z2);
-            Assert.Equal(0, infinity.Z3);
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
 
-            /* point at infinity with Z=0, Z2=0, Z3=0 (valid) */
-            var infinityValid = new ECPoint5w(999, 888, 0, 0, 0);
-            Assert.Equal(infinity, infinityValid);
-
-            /* invalid: point at infinity with non-zero Z2 */
-            Assert.Throws<InvalidOperationException>(() =>
-                new ECPoint5w(1, 1, 0, 1, 0));
-
-            /* invalid: point at infinity with non-zero Z3 */
-            Assert.Throws<InvalidOperationException>(() =>
-                new ECPoint5w(1, 1, 0, 0, 1));
-
-            /* equality: same coordinates */
-            var point2 = new ECPoint5w(10, 20, 3, 9, 27);
-            Assert.Equal(point1, point2);
+            Assert.True(point1.Equals(point2));
             Assert.True(point1 == point2);
+        }
 
-            /* equality: both infinity (valid representations) */
-            Assert.Equal(infinity, infinityValid);
-            Assert.True(infinity == infinityValid);
+        [Fact]
+        public void Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* inequality: different coordinates */
-            var point3 = new ECPoint5w(10, 21, 3, 9, 27);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
+            var point = new ECPoint(x, y);
+            Assert.True(point.Equals(point));
+            Assert.True(point == point);
+        }
 
-            /* inequality: finite vs infinity */
-            Assert.NotEqual(point1, infinity);
-            Assert.True(point1 != infinity);
+        [Fact]
+        public void Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint.POINT_INFINITY;
+            var inf2 = ECPoint.POINT_INFINITY;
 
-            /* hash code: finite points hash based on coordinates */
-            Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
 
-            /* hash code: all infinity points hash to same value */
-            Assert.Equal(infinity.GetHashCode(), infinityValid.GetHashCode());
-            Assert.Equal(0, infinity.GetHashCode());
+        [Fact]
+        public void Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10;
+            BigInteger x2 = 42, y2 = 100;
 
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+            var off1 = new ECPoint(x1, y1, false);
+            var off2 = new ECPoint(x2, y2, false);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10;
+
+            var point1 = new ECPoint(x1, y);
+            var point2 = new ECPoint(x2, y);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+
+            var point1 = new ECPoint(x, y1);
+            var point2 = new ECPoint(x, y2);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10;
+            BigInteger x2 = 15, y2 = 20;
+
+            var point1 = new ECPoint(x1, y1);
+            var point2 = new ECPoint(x2, y2);
+
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            var infinity = ECPoint.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint(x, y);
+            var offCurve = new ECPoint(x, y, false);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void Equals_SwappedCoordinates_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(y, x);
+
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void Equals_PointWithInfinityCoordinates_NotEqualToInfinity()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+
+            var point = new ECPoint(x, y);
+            var infinity = ECPoint.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var p1 = new ECPoint(x, y);
+            var p2 = new ECPoint(x, y);
+            var p3 = new ECPoint(x, y);
+
+            Assert.True(p1 == p2);
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var p1 = new ECPoint(x, y);
+            var p2 = new ECPoint(x, y);
+            var p3 = new ECPoint(x + 1, y);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
         }
 
         #endregion
 
-        #region Twisted Edwards Projective Tests (ECPoint3)
+        #region GetHashCode Tests
 
         [Fact]
-        public void ECPoint3_ConstructorAndEquality_HandlesAllCases()
+        public void GetHashCode_SamePoints_HaveSameHashCode()
         {
-            /* normal point construction */
-            var point1 = new ECPoint3(10, 20, 1);
-            Assert.Equal(10, point1.X);
-            Assert.Equal(20, point1.Y);
-            Assert.Equal(1, point1.Z);
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* point at infinity via static property */
-            var infinity = ECPoint3.POINT_INFINITY;
-            Assert.Equal(0, infinity.X);
-            Assert.Equal(1, infinity.Y);
-            Assert.Equal(0, infinity.Z);
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
 
-            /* point at infinity with arbitrary coordinates (Z=0) */
-            var infinityAlt = new ECPoint3(999, 888, 0);
-            Assert.Equal(infinity, infinityAlt);
+            Assert.Equal(point1.GetHashCode(), 
+                point2.GetHashCode());
+        }
 
-            /* equality: same coordinates */
-            var point2 = new ECPoint3(10, 20, 1);
-            Assert.Equal(point1, point2);
-            Assert.True(point1 == point2);
-
-            /* equality: both infinity (different X,Y but Z=0) */
-            Assert.Equal(infinity, infinityAlt);
-            Assert.True(infinity == infinityAlt);
-
-            /* inequality: different coordinates */
-            var point3 = new ECPoint3(10, 21, 1);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
-
-            /* inequality: finite vs infinity */
-            Assert.NotEqual(point1, infinity);
-            Assert.True(point1 != infinity);
-
-            /* hash code: finite points hash based on coordinates */
-            Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
-
-            /* hash code: all infinity points hash to same value */
-            Assert.Equal(infinity.GetHashCode(), infinityAlt.GetHashCode());
+        [Fact]
+        public void GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint.POINT_INFINITY;
             Assert.Equal(0, infinity.GetHashCode());
+        }
 
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+        [Fact]
+        public void GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10;
+            BigInteger x2 = 42, y2 = 100;
+
+            var off1 = new ECPoint(x1, y1, false);
+            var off2 = new ECPoint(x2, y2, false);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), 
+                off2.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x + 1, y);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1, -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    BigInteger x = xVal;
+                    BigInteger y = yVal;
+
+                    var point1 = new ECPoint(x, y);
+                    var point2 = new ECPoint(x, y);
+
+                    Assert.Equal(point1.GetHashCode(), 
+                        point2.GetHashCode());
+                }
+            }
         }
 
         #endregion
 
-        #region Twisted Edwards Extended Projective Tests (ECPoint4)
+        #region Collection Integration Tests
 
         [Fact]
-        public void ECPoint4_ConstructorAndEquality_HandlesAllCases()
+        public void HashSet_HandlesFinitePointsCorrectly()
         {
-            /* normal point construction */
-            var point1 = new ECPoint4(10, 20, 200, 1);
-            Assert.Equal(10, point1.X);
-            Assert.Equal(20, point1.Y);
-            Assert.Equal(200, point1.T);
-            Assert.Equal(1, point1.Z);
+            BigInteger x1 = 5, y1 = 10;
+            BigInteger x2 = 15, y2 = 20;
 
-            /* point at infinity via static property */
-            var infinity = ECPoint4.POINT_INFINITY;
-            Assert.Equal(0, infinity.X);
-            Assert.Equal(1, infinity.Y);
-            Assert.Equal(0, infinity.T);
-            Assert.Equal(0, infinity.Z);
+            var set = new HashSet<ECPoint>();
+            var p1 = new ECPoint(x1, y1);
 
-            /* point at infinity with Z=0 and T=0 (valid) */
-            var infinityValid = new ECPoint4(999, 888, 0, 0);
-            Assert.Equal(infinity, infinityValid);
+            var p2 = new ECPoint(x1, y1);
+            var p3 = new ECPoint(x2, y2);
 
-            /* invalid: point at infinity with non-zero T */
-            Assert.Throws<InvalidOperationException>(() =>
-                new ECPoint4(1, 1, 5, 0));
+            set.Add(p1);
+            Assert.Single(set);
 
-            /* equality: same coordinates (X,Y,Z only, T is derived) */
-            var point2 = new ECPoint4(10, 20, 200, 1);
-            Assert.Equal(point1, point2);
-            Assert.True(point1 == point2);
+            Assert.True(set.Contains(p2));
+            Assert.False(set.Contains(p3));
+        }
 
-            /* points with different T but same X,Y,Z are not equal */
-            var pointDifferentT = new ECPoint4(10, 20, 999, 1);
-            Assert.NotEqual(point1, pointDifferentT);
-            Assert.False(point1 == pointDifferentT);
+        [Fact]
+        public void HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint>();
+            var inf1 = ECPoint.POINT_INFINITY;
+            BigInteger x = 42;
+            BigInteger y = 100;
 
-            /* equality: both infinity (valid representations) */
-            Assert.Equal(infinity, infinityValid);
-            Assert.True(infinity == infinityValid);
+            var inf2 = new ECPoint(x, y, false);
+            set.Add(inf1);
 
-            /* inequality: different coordinates */
-            var point3 = new ECPoint4(10, 21, 210, 1);
-            Assert.NotEqual(point1, point3);
-            Assert.True(point1 != point3);
+            Assert.Single(set);
+            Assert.True(set.Contains(inf2));
+        }
 
-            /* inequality: finite vs infinity */
-            Assert.NotEqual(point1, infinity);
-            Assert.True(point1 != infinity);
+        [Fact]
+        public void Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
 
-            /* hash code: finite points hash based on coordinates */
+            var dict = new Dictionary<ECPoint, string>();
+            var p1 = new ECPoint(x, y);
+            var p2 = new ECPoint(x, y);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var list = new List<ECPoint>();
+            var p1 = new ECPoint(x, y);
+            var p2 = new ECPoint(x, y);
+
+            list.Add(p1);
+            Assert.True(list.Contains(p2));
+        }
+
+        [Fact]
+        public void List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint>();
+            var inf1 = ECPoint.POINT_INFINITY;
+            var inf2 = ECPoint.POINT_INFINITY;
+
+            list.Add(inf1);
+            Assert.True(list.Contains(inf2));
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var point = new ECPoint(x, y);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var original = new ECPoint(x, y);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void Points_CanRepresentSecp256k1Generator()
+        {
+            /* secp256k1 generator point coordinates */
+            var gx = BigInteger.Parse("55066263022277343669578718895168534326250603453777594175500187360389116729240");
+            var gy = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            var generator = new ECPoint(gx, gy);
+            Assert.False(generator.IsInfinity);
+
+            Assert.Equal(gx, generator.GetAffineX());
+            Assert.Equal(gy, generator.GetAffineY());
+        }
+
+        [Fact]
+        public void Points_WithLargeCoordinates_EqualityWorks()
+        {
+            var x = BigInteger.Parse("1234567890123456789012345678901234567890");
+            var y = BigInteger.Parse("9876543210987654321098765432109876543210");
+
+            var point1 = new ECPoint(x, y);
+            var point2 = new ECPoint(x, y);
+
+            Assert.True(point1.Equals(point2));
             Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
-            Assert.NotEqual(point1.GetHashCode(), point3.GetHashCode());
+        }
 
-            /* points with different T have different hash code */
-            Assert.NotEqual(point1.GetHashCode(), pointDifferentT.GetHashCode());
+        #endregion
 
-            /* hash code: all infinity points hash to same value */
-            Assert.Equal(infinity.GetHashCode(), infinityValid.GetHashCode());
-            Assert.Equal(0, infinity.GetHashCode());
+        #region Stress Tests
 
-            /* null comparison */
-            Assert.False(point1.Equals(null));
-            Assert.False(point1.Equals("not a point"));
+        [Fact]
+        public void ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                var point = new ECPoint(x, y);
+                Assert.Equal(x, point.GetAffineX());
+                Assert.Equal(y, point.GetAffineY());
+            }
+        }
+
+        [Fact]
+        public void HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                var point = new ECPoint(x, y);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 95);
         }
 
         #endregion

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -292,17 +292,17 @@ namespace Eduard.Tests.Curves
         {
             /* normal point construction */
             var point1 = new ECPoint4(10, 20, 200, 1);
-            Assert.Equal(10, point1.x);
-            Assert.Equal(20, point1.y);
-            Assert.Equal(200, point1.t);
-            Assert.Equal(1, point1.z);
+            Assert.Equal(10, point1.X);
+            Assert.Equal(20, point1.Y);
+            Assert.Equal(200, point1.T);
+            Assert.Equal(1, point1.Z);
 
             /* point at infinity via static property */
             var infinity = ECPoint4.POINT_INFINITY;
-            Assert.Equal(0, infinity.x);
-            Assert.Equal(1, infinity.y);
-            Assert.Equal(0, infinity.t);
-            Assert.Equal(0, infinity.z);
+            Assert.Equal(0, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.T);
+            Assert.Equal(0, infinity.Z);
 
             /* point at infinity with Z=0 and T=0 (valid) */
             var infinityValid = new ECPoint4(999, 888, 0, 0);
@@ -349,12 +349,6 @@ namespace Eduard.Tests.Curves
             /* null comparison */
             Assert.False(point1.Equals(null));
             Assert.False(point1.Equals("not a point"));
-
-            /* invariant violation detection in Equals */
-            var invalidInfinity = new ECPoint4(0, 0, 0, 0);
-            invalidInfinity.t = 5;
-            Assert.Throws<InvalidOperationException>(() =>
-                invalidInfinity.Equals(infinity));
         }
 
         #endregion

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -58,15 +58,15 @@ namespace Eduard.Tests.Curves
         {
             /* normal point construction */
             var point1 = new ECPoint3w(10, 20, 1);
-            Assert.Equal(10, point1.x);
-            Assert.Equal(20, point1.y);
-            Assert.Equal(1, point1.z);
+            Assert.Equal(10, point1.X);
+            Assert.Equal(20, point1.Y);
+            Assert.Equal(1, point1.Z);
 
             /* point at infinity via static property */
             var infinity = ECPoint3w.POINT_INFINITY;
-            Assert.Equal(1, infinity.x);
-            Assert.Equal(1, infinity.y);
-            Assert.Equal(0, infinity.z);
+            Assert.Equal(1, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
 
             /* point at infinity with arbitrary coordinates (Z=0) */
             var infinityAlt = new ECPoint3w(999, 888, 0);

--- a/UnitTests/Tests/Curves/PointTests.cs
+++ b/UnitTests/Tests/Curves/PointTests.cs
@@ -22,7 +22,7 @@ namespace Eduard.Tests.Curves
             Assert.Equal(1, infinity.GetAffineY());
 
             /* point at infinity via constructor with flag */
-            var infinity2 = new ECPoint(0, 1, true);
+            var infinity2 = new ECPoint(0, 1, false);
             Assert.Equal(infinity, infinity2);
 
             /* equality: same coordinates */
@@ -112,16 +112,16 @@ namespace Eduard.Tests.Curves
         {
             /* normal point construction */
             var point1 = new ECPoint4w(10, 20, 5, 100);
-            Assert.Equal(10, point1.x);
-            Assert.Equal(20, point1.y);
-            Assert.Equal(5, point1.z);
+            Assert.Equal(10, point1.X);
+            Assert.Equal(20, point1.Y);
+            Assert.Equal(5, point1.Z);
             Assert.Equal(100, point1.aZ4);
 
             /* point at infinity via static property */
             var infinity = ECPoint4w.POINT_INFINITY;
-            Assert.Equal(1, infinity.x);
-            Assert.Equal(1, infinity.y);
-            Assert.Equal(0, infinity.z);
+            Assert.Equal(1, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
             Assert.Equal(0, infinity.aZ4);
 
             /* point at infinity with Z=0 and aZ4=0 (valid) */
@@ -161,12 +161,6 @@ namespace Eduard.Tests.Curves
             /* null comparison */
             Assert.False(point1.Equals(null));
             Assert.False(point1.Equals("not a point"));
-
-            /* invariant violation detection in Equals */
-            var invalidInfinity = new ECPoint4w(0, 0, 0, 0);
-            invalidInfinity.aZ4 = 5;
-            Assert.Throws<InvalidOperationException>(() =>
-                invalidInfinity.Equals(infinity));
         }
 
         #endregion

--- a/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
+++ b/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
@@ -47,11 +47,11 @@ namespace Eduard.Tests.Curves
             var negP = Ed3Math.Negate(curve, P);
 
             /* homogenous projective coordinate checks */
-            Assert.Equal(P.y, negP.y);
-            var expectedNegX = p - P.x;
+            Assert.Equal(P.Y, negP.Y);
+            var expectedNegX = p - P.X;
 
-            Assert.Equal(expectedNegX, negP.x);
-            Assert.Equal(P.z, negP.z);
+            Assert.Equal(expectedNegX, negP.X);
+            Assert.Equal(P.Z, negP.Z);
 
             /* affine consistency */
             var affineNegP = curve.ToAffine(negP);

--- a/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
+++ b/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
@@ -8,8 +8,9 @@ namespace Eduard.Tests.Curves
     public class TwistedEdwardsMathTests
     {
         #region Point Negation Tests — All Coordinate Systems
+
         [Fact]
-        public void Negate_Affine()
+        public void Negate_Affine_BasePoint_Properties()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -35,7 +36,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Negate_Projective()
+        public void Negate_Projective_BasePoint_Properties()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -72,7 +73,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Negate_Extended_Projective()
+        public void Negate_ExtendedProjective_BasePoint_Properties()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -110,11 +111,13 @@ namespace Eduard.Tests.Curves
             var inf = ECPoint4.POINT_INFINITY;
             Assert.Equal(inf, Ed4Math.Negate(curve, inf));
         }
+
         #endregion
 
         #region Point Doubling — All Coordinate Systems
+
         [Fact]
-        public void Double_Affine()
+        public void Double_Affine_BasePoint_Properties()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -151,7 +154,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Double_Projective()
+        public void Double_Projective_BasePoint_ConsistentWithAffine()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -198,7 +201,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Double_Extended_Projective()
+        public void Double_ExtendedProjective_BasePoint_ConsistentWithAffine()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -243,11 +246,13 @@ namespace Eduard.Tests.Curves
                 randomPoint, randomPoint);
             Assert.Equal(expectedDoubleR, affineDoubleR);
         }
+
         #endregion
 
-        #region #region Point Addition — All Coordinate Systems
+        #region Point Addition — All Coordinate Systems
+
         [Fact]
-        public void Add_Affine()
+        public void Add_Affine_BasePoint_VerifiesGroupLaws()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -289,7 +294,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Add_Projective()
+        public void Add_Projective_BasePoint_ConsistentWithAffine()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -350,7 +355,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Add_Extended_Projective()
+        public void Add_ExtendedProjective_BasePoint_ConsistentWithAffine()
         {
             TwistedEdwardsCurveType curveType = TwistedEdwardsCurveType.Edwards25519;
             var curve = TwistedEdwardsCurve.GetNamedCurve(curveType);
@@ -409,6 +414,7 @@ namespace Eduard.Tests.Curves
             var expectedAffineSum = TwistedEdwardsMath.Add(curve, randomA, randomB);
             Assert.Equal(expectedAffineSum, affineEProjSum);
         }
+
         #endregion
     }
 }

--- a/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
+++ b/UnitTests/Tests/Curves/TwistedEdwardsMathTests.cs
@@ -84,14 +84,14 @@ namespace Eduard.Tests.Curves
             var negP = Ed4Math.Negate(curve, P);
 
             /* extended projective coordinate checks */
-            Assert.Equal(P.y, negP.y);
-            var expectedNegX = p - P.x;
+            Assert.Equal(P.Y, negP.Y);
+            var expectedNegX = p - P.X;
 
-            Assert.Equal(expectedNegX, negP.x);
-            BigInteger expectedNegT = p - P.t;
+            Assert.Equal(expectedNegX, negP.X);
+            BigInteger expectedNegT = p - P.T;
 
-            Assert.Equal(expectedNegT, negP.t);
-            Assert.Equal(P.z, negP.z);
+            Assert.Equal(expectedNegT, negP.T);
+            Assert.Equal(P.Z, negP.Z);
 
             /* affine consistency */
             var affineNegP = curve.ToAffine(negP);

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -563,6 +563,44 @@ namespace Eduard.Tests.Curves
                 ECMath.Add(curve, null, points));
         }
 
+        [Fact]
+        public void AddBatch_MatchesScalarAdd_ForAllBoundaryCases()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] left = new ECPoint[5];
+            ECPoint[] right = new ECPoint[5];
+
+            ECPoint[] sum = new ECPoint[5];
+            int j, k;
+
+            left[0] = ECPoint.POINT_INFINITY;
+            right[0] = curve.GetBasePoint();
+
+            left[1] = curve.GetBasePoint();
+            right[1] = ECPoint.POINT_INFINITY;
+
+            left[2] = ECPoint.POINT_INFINITY;
+            right[2] = ECPoint.POINT_INFINITY;
+
+            left[3] = curve.GetBasePoint();
+            right[3] = left[1];
+
+            left[4] = curve.GetBasePoint();
+            right[4] = ECMath.Negate(curve, 
+                left[4]);
+
+            for (j = 0; j < 5; j++)
+                sum[j] = ECMath.Add(curve,
+                    left[j], right[j]);
+
+            ECMath.Add(curve, left, right);
+
+            for (k = 0; k < 5; k++)
+                Assert.Equal(right[k], sum[k]);
+        }
+
         #endregion
     }
 }

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -564,6 +564,42 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
+        public void AddBatch_MismatchedLengths_ThrowsArgumentException()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] left = new ECPoint[4];
+            ECPoint[] right = new ECPoint[6];
+            int j, k;
+
+            for(j = 0; j < 4; j++)
+            {
+                left[j] = ECPoint.POINT_INFINITY;
+                right[j] = ECPoint.POINT_INFINITY;
+            }
+
+            for (j = 4; j < 6; j++)
+                right[j] = ECPoint.POINT_INFINITY;
+
+            Assert.Throws<ArgumentException>(() =>
+                ECMath.Add(curve, left, right));
+        }
+
+        [Fact]
+        public void AddBatch_EmptyArrays_Succeeds()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] left = new ECPoint[0];
+            ECPoint[] right = new ECPoint[0];
+
+            ECMath.Add(curve, left, right);
+            Assert.True(right.Length == 0);
+        }
+
+        [Fact]
         public void AddBatch_MatchesScalarAdd_ForAllBoundaryCases()
         {
             var curve = EllipticCurve.GetNamedCurve(

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -1,4 +1,5 @@
-﻿using Eduard.Security.Curves;
+﻿using System;
+using Eduard.Security.Curves;
 using Eduard.Security.Extensions;
 using Eduard.Security.Primitives;
 
@@ -315,7 +316,7 @@ namespace Eduard.Tests.Curves
         }
         #endregion
 
-        #region #region Point Addition — All Coordinate Systems
+        #region Point Addition — All Coordinate Systems
         [Fact]
         public void Add_Affine()
         {
@@ -526,6 +527,26 @@ namespace Eduard.Tests.Curves
             var expectedAffineSum = ECMath.Add(curve, randomA, randomB);
             Assert.Equal(expectedAffineSum, affineJcSum);
         }
+        #endregion
+
+        #region Point Multi-Addition - Affine Coordinate System
+
+        [Fact]
+        public void AddBatch_NullLeftArray_ThrowsArgumentNullException()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] points = new ECPoint[5];
+            int j, k;
+
+            for (j = 0; j < points.Length; j++)
+                points[j] = ECPoint.POINT_INFINITY;
+
+            Assert.Throws<ArgumentNullException>(() => 
+                ECMath.Add(curve, points, null));
+        }
+
         #endregion
     }
 }

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -45,11 +45,11 @@ namespace Eduard.Tests.Curves
             var negP = Wei3Math.Negate(curve, P);
 
             /* Jacobian coordinate checks */
-            Assert.Equal(P.x, negP.x);
-            var expectedNegY = p - P.y;
+            Assert.Equal(P.X, negP.X);
+            var expectedNegY = p - P.Y;
 
-            Assert.Equal(expectedNegY, negP.y);
-            Assert.Equal(P.z, negP.z);
+            Assert.Equal(expectedNegY, negP.Y);
+            Assert.Equal(P.Z, negP.Z);
 
             /* affine consistency */
             var affineNegP = curve.ToAffine(negP);

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -117,11 +117,11 @@ namespace Eduard.Tests.Curves
             var negP = Wei5Math.Negate(curve, P);
 
             /* Jacobian-Chudnovsky coordinate checks */
-            Assert.Equal(P.x, negP.x);
-            var expectedNegY = p - P.y;
+            Assert.Equal(P.X, negP.X);
+            var expectedNegY = p - P.Y;
 
-            Assert.Equal(expectedNegY, negP.y);
-            Assert.Equal(P.z, negP.z);
+            Assert.Equal(expectedNegY, negP.Y);
+            Assert.Equal(P.Z, negP.Z);
 
             /* affine consistency */
             var affineNegP = curve.ToAffine(negP);

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -81,11 +81,11 @@ namespace Eduard.Tests.Curves
             var negP = Wei4Math.Negate(curve, P);
 
             /* modified Jacobian coordinate checks */
-            Assert.Equal(P.x, negP.x);
-            var expectedNegY = p - P.y;
+            Assert.Equal(P.X, negP.X);
+            var expectedNegY = p - P.Y;
 
-            Assert.Equal(expectedNegY, negP.y);
-            Assert.Equal(P.z, negP.z);
+            Assert.Equal(expectedNegY, negP.Y);
+            Assert.Equal(P.Z, negP.Z);
 
             /* affine consistency */
             var affineNegP = curve.ToAffine(negP);

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -601,6 +601,33 @@ namespace Eduard.Tests.Curves
                 Assert.Equal(right[k], sum[k]);
         }
 
+        [Fact]
+        public void AddBatch_MatchesScalarAdd()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] left = new ECPoint[5];
+            ECPoint[] right = new ECPoint[5];
+
+            ECPoint[] sum = new ECPoint[5];
+            int j, k;
+
+            for (j = 0; j < 5; j++)
+            {
+                left[j] = curve.GetBasePoint();
+                right[j] = curve.GetBasePoint();
+
+                sum[j] = ECMath.Add(curve,
+                    left[j], right[j]);
+            }
+
+            ECMath.Add(curve, left, right);
+
+            for (k = 0; k < 5; k++)
+                Assert.Equal(right[k], sum[k]);
+        }
+
         #endregion
     }
 }

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -9,8 +9,9 @@ namespace Eduard.Tests.Curves
     public class WeiMathTests
     {
         #region Point Negation Tests — All Coordinate Systems
+
         [Fact]
-        public void Negate_Affine()
+        public void Negate_Affine_BasePoint_Properties()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
             var p = curve.field;
@@ -35,7 +36,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Negate_Jacobian()
+        public void Negate_Jacobian_BasePoint_Properties()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
             var p = curve.field;
@@ -71,7 +72,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Negate_ModifiedJacobian()
+        public void Negate_ModifiedJacobian_BasePoint_Properties()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
             var p = curve.field;
@@ -107,7 +108,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Negate_JacobianChudnovsky()
+        public void Negate_JacobianChudnovsky_BasePoint_Properties()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
             var p = curve.field;
@@ -141,11 +142,13 @@ namespace Eduard.Tests.Curves
             var inf = ECPoint5w.POINT_INFINITY;
             Assert.Equal(inf, Wei5Math.Negate(curve, inf));
         }
+
         #endregion
 
         #region Point Doubling — All Coordinate Systems
+
         [Fact]
-        public void Double_Affine()
+        public void Double_Affine_BasePoint_Properties()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -181,7 +184,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Double_Jacobian()
+        public void Double_Jacobian_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -226,7 +229,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Double_ModifiedJacobian()
+        public void Double_ModifiedJacobian_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -271,7 +274,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Double_JacobianChudnovsky()
+        public void Double_JacobianChudnovsky_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -314,11 +317,13 @@ namespace Eduard.Tests.Curves
             var expectedDoubleR = ECMath.Add(curve, randomPoint, randomPoint);
             Assert.Equal(expectedDoubleR, affineDoubleR);
         }
+
         #endregion
 
         #region Point Addition — All Coordinate Systems
+
         [Fact]
-        public void Add_Affine()
+        public void Add_Affine_BasePoint_VerifiesGroupLaws()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -359,7 +364,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Add_Jacobian()
+        public void Add_Jacobian_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -415,7 +420,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Add_ModifiedJacobian()
+        public void Add_ModifiedJacobian_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -472,7 +477,7 @@ namespace Eduard.Tests.Curves
         }
 
         [Fact]
-        public void Add_JacobianChudnovsky()
+        public void Add_JacobianChudnovsky_BasePoint_ConsistentWithAffine()
         {
             var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
 
@@ -527,6 +532,7 @@ namespace Eduard.Tests.Curves
             var expectedAffineSum = ECMath.Add(curve, randomA, randomB);
             Assert.Equal(expectedAffineSum, affineJcSum);
         }
+
         #endregion
 
         #region Point Multi-Addition - Affine Coordinate System

--- a/UnitTests/Tests/Curves/WeiMathTests.cs
+++ b/UnitTests/Tests/Curves/WeiMathTests.cs
@@ -547,6 +547,22 @@ namespace Eduard.Tests.Curves
                 ECMath.Add(curve, points, null));
         }
 
+        [Fact]
+        public void AddBatch_NullRightArray_ThrowsArgumentNullException()
+        {
+            var curve = EllipticCurve.GetNamedCurve(
+                WeiCurveType.NistP256);
+
+            ECPoint[] points = new ECPoint[5];
+            int j, k;
+
+            for (j = 0; j < points.Length; j++)
+                points[j] = ECPoint.POINT_INFINITY;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                ECMath.Add(curve, null, points));
+        }
+
         #endregion
     }
 }

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -115,6 +115,27 @@ namespace Eduard.Tests.Extensions
             Assert.Equal(ECPoint.POINT_INFINITY, affinePoint);
         }
 
+        [Fact]
+        public void ToAffine_FromModifiedJacobianWithZeroZ_ReturnsInfinity()
+        {
+            var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
+            var G = curve.GetBasePoint();
+            var modJacPoint = curve.ToModifiedJacobian(G);
+
+            /* test security check inside the constructor */
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var invalidPoint = new ECPoint4w(modJacPoint.X,
+                    modJacPoint.Y, 0, modJacPoint.aZ4);
+            });
+
+            var infinity = new ECPoint4w(modJacPoint.X,
+                modJacPoint.Y, 0, 0);
+
+            Assert.Equal(infinity,
+                ECPoint4w.POINT_INFINITY);
+        }
+
         #endregion
 
         #region Weierstrass Curve — Affine to Jacobian-Chudnovsky Conversions

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -128,12 +128,12 @@ namespace Eduard.Tests.Extensions
             var jcPoint = curve.ToJacobianChudnovsky(G);
             Assert.NotEqual(ECPoint5w.POINT_INFINITY, jcPoint);
 
-            Assert.Equal(G.GetAffineX(), jcPoint.x);
-            Assert.Equal(G.GetAffineY(), jcPoint.y);
+            Assert.Equal(G.GetAffineX(), jcPoint.X);
+            Assert.Equal(G.GetAffineY(), jcPoint.Y);
 
-            Assert.Equal(1, jcPoint.z);
-            Assert.Equal(1, jcPoint.z2);
-            Assert.Equal(1, jcPoint.z3);
+            Assert.Equal(1, jcPoint.Z);
+            Assert.Equal(1, jcPoint.Z2);
+            Assert.Equal(1, jcPoint.Z3);
         }
 
         [Fact]
@@ -173,19 +173,12 @@ namespace Eduard.Tests.Extensions
 
             /* security checks inside constructor */
             Assert.Throws<InvalidOperationException>(() => {
-                var invalidPoint = new ECPoint5w(jcPoint.x,
-                    jcPoint.y, 0, jcPoint.z2, jcPoint.z3);           
-            });
-
-            /* struct mutation outside of constructor */
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                jcPoint.z = 0;
-                var affinePoint = curve.ToAffine(jcPoint);
+                var invalidPoint = new ECPoint5w(jcPoint.X,
+                    jcPoint.Y, 0, jcPoint.Z2, jcPoint.Z3);           
             });
 
             var validPointInfinity = new ECPoint5w(
-                jcPoint.x, jcPoint.y, 0, 0, 0);
+                jcPoint.X, jcPoint.Y, 0, 0, 0);
 
             var affinePoint = curve.ToAffine(validPointInfinity);
             Assert.True(affinePoint == ECPoint.POINT_INFINITY);
@@ -229,10 +222,10 @@ namespace Eduard.Tests.Extensions
             var jacPoint = curve.ToJacobian(jcPoint);
 
             Assert.NotEqual(ECPoint3w.POINT_INFINITY, jacPoint);
-            Assert.Equal(jcPoint.x, jacPoint.X);
+            Assert.Equal(jcPoint.X, jacPoint.X);
 
-            Assert.Equal(jcPoint.y, jacPoint.Y);
-            Assert.Equal(jcPoint.z, jacPoint.Z);
+            Assert.Equal(jcPoint.Y, jacPoint.Y);
+            Assert.Equal(jcPoint.Z, jacPoint.Z);
         }
 
         [Fact]
@@ -286,12 +279,12 @@ namespace Eduard.Tests.Extensions
             BigInteger p = curve.field;
 
             Assert.NotEqual(ECPoint4w.POINT_INFINITY, modJacPoint);
-            Assert.Equal(jcPoint.x, modJacPoint.X);
-            Assert.Equal(jcPoint.y, modJacPoint.Y);
-            Assert.Equal(jcPoint.z, modJacPoint.Z);
+            Assert.Equal(jcPoint.X, modJacPoint.X);
+            Assert.Equal(jcPoint.Y, modJacPoint.Y);
+            Assert.Equal(jcPoint.Z, modJacPoint.Z);
 
             /* verify aZ^4 = a * (Z^2)^2 using precomputed Z^2 */
-            var expectedZ4 = (jcPoint.z2 * jcPoint.z2) % p;
+            var expectedZ4 = (jcPoint.Z2 * jcPoint.Z2) % p;
             var expectedAZ4 = (curve.a * expectedZ4) % p;
             Assert.Equal(expectedAZ4, modJacPoint.aZ4);
         }

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -311,10 +311,10 @@ namespace Eduard.Tests.Extensions
             var projPoint = curve.ToProjective(G);
 
             Assert.NotEqual(ECPoint3.POINT_INFINITY, projPoint);
-            Assert.Equal(G.GetAffineX(), projPoint.x);
+            Assert.Equal(G.GetAffineX(), projPoint.X);
 
-            Assert.Equal(G.GetAffineY(), projPoint.y);
-            Assert.Equal(1, projPoint.z);
+            Assert.Equal(G.GetAffineY(), projPoint.Y);
+            Assert.Equal(1, projPoint.Z);
         }
 
         [Fact]
@@ -367,7 +367,7 @@ namespace Eduard.Tests.Extensions
             var G = curve.GetBasePoint();
             var projPoint = curve.ToProjective(G);
 
-            var invalidPoint = new ECPoint3(projPoint.x, projPoint.y, 0);
+            var invalidPoint = new ECPoint3(projPoint.X, projPoint.Y, 0);
             var affinePoint = curve.ToAffine(invalidPoint);
             Assert.Equal(ECPoint.POINT_INFINITY, affinePoint);
         }
@@ -488,10 +488,10 @@ namespace Eduard.Tests.Extensions
             Assert.NotEqual(ECPoint4.POINT_INFINITY, extPoint);
 
             /* extended coordinates should be (XZ, YZ, XY, Z^2) */
-            var expectedX = (projPoint.x * projPoint.z) % p;
-            var expectedY = (projPoint.y * projPoint.z) % p;
-            var expectedT = (projPoint.x * projPoint.y) % p;
-            var expectedZ = (projPoint.z * projPoint.z) % p;
+            var expectedX = (projPoint.X * projPoint.Z) % p;
+            var expectedY = (projPoint.Y * projPoint.Z) % p;
+            var expectedT = (projPoint.X * projPoint.Y) % p;
+            var expectedZ = (projPoint.Z * projPoint.Z) % p;
 
             Assert.Equal(expectedX, extPoint.x);
             Assert.Equal(expectedY, extPoint.y);
@@ -520,9 +520,9 @@ namespace Eduard.Tests.Extensions
             var copyPoint = curve.GetPointCopy(projPoint);
             Assert.NotEqual(ECPoint4.POINT_INFINITY, copyPoint);
 
-            Assert.Equal(projPoint.x, copyPoint.x);
-            Assert.Equal(projPoint.y, copyPoint.y);
-            Assert.Equal(projPoint.z, copyPoint.z);
+            Assert.Equal(projPoint.X, copyPoint.x);
+            Assert.Equal(projPoint.Y, copyPoint.y);
+            Assert.Equal(projPoint.Z, copyPoint.z);
             Assert.Equal(0, copyPoint.t);
         }
 
@@ -547,9 +547,9 @@ namespace Eduard.Tests.Extensions
             var projPoint = curve.ToProjective(extPoint);
             Assert.NotEqual(ECPoint3.POINT_INFINITY, projPoint);
 
-            Assert.Equal(extPoint.x, projPoint.x);
-            Assert.Equal(extPoint.y, projPoint.y);
-            Assert.Equal(extPoint.z, projPoint.z);
+            Assert.Equal(extPoint.x, projPoint.X);
+            Assert.Equal(extPoint.y, projPoint.Y);
+            Assert.Equal(extPoint.z, projPoint.Z);
         }
 
         [Fact]
@@ -665,9 +665,9 @@ namespace Eduard.Tests.Extensions
             var extPoint = curve.ToExtendedProjective(projPoint);
             var recoveredProjPoint = curve.ToProjective(extPoint);
 
-            Assert.Equal(projPoint.x, recoveredProjPoint.x);
-            Assert.Equal(projPoint.y, recoveredProjPoint.y);
-            Assert.Equal(projPoint.z, recoveredProjPoint.z);
+            Assert.Equal(projPoint.X, recoveredProjPoint.X);
+            Assert.Equal(projPoint.Y, recoveredProjPoint.Y);
+            Assert.Equal(projPoint.Z, recoveredProjPoint.Z);
         }
 
         #endregion
@@ -711,9 +711,9 @@ namespace Eduard.Tests.Extensions
             /* scale projective coordinates by lambda */
             var projPoint = curve.ToProjective(G);
             var scaledProjPoint = new ECPoint3(
-                (projPoint.x * lambda) % p,
-                (projPoint.y * lambda) % p,
-                (projPoint.z * lambda) % p
+                (projPoint.X * lambda) % p,
+                (projPoint.Y * lambda) % p,
+                (projPoint.Z * lambda) % p
             );
 
             var extPoint = curve.ToExtendedProjective(scaledProjPoint);

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -18,10 +18,10 @@ namespace Eduard.Tests.Extensions
 
             var jacPoint = curve.ToJacobian(G);
             Assert.NotEqual(ECPoint3w.POINT_INFINITY, jacPoint);
-            Assert.Equal(G.GetAffineX(), jacPoint.x);
+            Assert.Equal(G.GetAffineX(), jacPoint.X);
 
-            Assert.Equal(G.GetAffineY(), jacPoint.y);
-            Assert.Equal(1, jacPoint.z);
+            Assert.Equal(G.GetAffineY(), jacPoint.Y);
+            Assert.Equal(1, jacPoint.Z);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Eduard.Tests.Extensions
             var jacPoint = curve.ToJacobian(G);
 
             /* create invalid point with Z = 0 */
-            var invalidPoint = new ECPoint3w(jacPoint.x, jacPoint.y, 0);
+            var invalidPoint = new ECPoint3w(jacPoint.X, jacPoint.Y, 0);
             var affinePoint = curve.ToAffine(invalidPoint);
             Assert.Equal(ECPoint.POINT_INFINITY, affinePoint);
         }
@@ -205,10 +205,10 @@ namespace Eduard.Tests.Extensions
             var jacPoint = curve.ToJacobian(modJacPoint);
 
             Assert.NotEqual(ECPoint3w.POINT_INFINITY, jacPoint);
-            Assert.Equal(modJacPoint.X, jacPoint.x);
+            Assert.Equal(modJacPoint.X, jacPoint.X);
 
-            Assert.Equal(modJacPoint.Y, jacPoint.y);
-            Assert.Equal(modJacPoint.Z, jacPoint.z);
+            Assert.Equal(modJacPoint.Y, jacPoint.Y);
+            Assert.Equal(modJacPoint.Z, jacPoint.Z);
         }
 
         [Fact]
@@ -229,10 +229,10 @@ namespace Eduard.Tests.Extensions
             var jacPoint = curve.ToJacobian(jcPoint);
 
             Assert.NotEqual(ECPoint3w.POINT_INFINITY, jacPoint);
-            Assert.Equal(jcPoint.x, jacPoint.x);
+            Assert.Equal(jcPoint.x, jacPoint.X);
 
-            Assert.Equal(jcPoint.y, jacPoint.y);
-            Assert.Equal(jcPoint.z, jacPoint.z);
+            Assert.Equal(jcPoint.y, jacPoint.Y);
+            Assert.Equal(jcPoint.z, jacPoint.Z);
         }
 
         [Fact]
@@ -255,12 +255,12 @@ namespace Eduard.Tests.Extensions
             BigInteger p = curve.field;
 
             Assert.NotEqual(ECPoint4w.POINT_INFINITY, modJacPoint);
-            Assert.Equal(jacPoint.x, modJacPoint.X);
-            Assert.Equal(jacPoint.y, modJacPoint.Y);
-            Assert.Equal(jacPoint.z, modJacPoint.Z);
+            Assert.Equal(jacPoint.X, modJacPoint.X);
+            Assert.Equal(jacPoint.Y, modJacPoint.Y);
+            Assert.Equal(jacPoint.Z, modJacPoint.Z);
 
             /* verify aZ^4 is correctly computed */
-            var expectedZ2 = (jacPoint.z * jacPoint.z) % p;
+            var expectedZ2 = (jacPoint.Z * jacPoint.Z) % p;
             var expectedZ4 = (expectedZ2 * expectedZ2) % p;
             var expectedAZ4 = (curve.a * expectedZ4) % p;
             Assert.Equal(expectedAZ4, modJacPoint.aZ4);
@@ -616,9 +616,9 @@ namespace Eduard.Tests.Extensions
             var modJacPoint = curve.ToModifiedJacobian(jacPoint);
             var recoveredJacPoint = curve.ToJacobian(modJacPoint);
 
-            Assert.Equal(jacPoint.x, recoveredJacPoint.x);
-            Assert.Equal(jacPoint.y, recoveredJacPoint.y);
-            Assert.Equal(jacPoint.z, recoveredJacPoint.z);
+            Assert.Equal(jacPoint.X, recoveredJacPoint.X);
+            Assert.Equal(jacPoint.Y, recoveredJacPoint.Y);
+            Assert.Equal(jacPoint.Z, recoveredJacPoint.Z);
         }
 
         [Fact]

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -79,10 +79,10 @@ namespace Eduard.Tests.Extensions
             var modJacPoint = curve.ToModifiedJacobian(G);
             Assert.NotEqual(ECPoint4w.POINT_INFINITY, modJacPoint);
 
-            Assert.Equal(G.GetAffineX(), modJacPoint.x);
-            Assert.Equal(G.GetAffineY(), modJacPoint.y);
+            Assert.Equal(G.GetAffineX(), modJacPoint.X);
+            Assert.Equal(G.GetAffineY(), modJacPoint.Y);
 
-            Assert.Equal(1, modJacPoint.z);
+            Assert.Equal(1, modJacPoint.Z);
             Assert.Equal(curve.a, modJacPoint.aZ4);
         }
 
@@ -113,35 +113,6 @@ namespace Eduard.Tests.Extensions
             var inf = ECPoint4w.POINT_INFINITY;
             var affinePoint = curve.ToAffine(inf);
             Assert.Equal(ECPoint.POINT_INFINITY, affinePoint);
-        }
-
-        [Fact]
-        public void ToAffine_FromModifiedJacobianWithZeroZ_ReturnsInfinity()
-        {
-            var curve = EllipticCurve.GetNamedCurve(WeiCurveType.NistP256);
-            var G = curve.GetBasePoint();
-            var modJacPoint = curve.ToModifiedJacobian(G);
-
-            /* test security check inside the constructor */
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                var invalidPoint = new ECPoint4w(modJacPoint.x,
-                    modJacPoint.y, 0, modJacPoint.aZ4);
-            });
-
-            /* mutate data outside of struct */
-            var invalidPoint = new ECPoint4w(modJacPoint.x,
-                modJacPoint.y, modJacPoint.z, modJacPoint.aZ4);
-            invalidPoint.z = 0;
-
-            /* throw it successfully */
-            Assert.Throws<InvalidOperationException>(() => 
-                curve.ToAffine(invalidPoint));
-
-            /* mutate again to fit point at infinity */
-            invalidPoint.aZ4 = 0;
-            Assert.Equal(invalidPoint, 
-                ECPoint4w.POINT_INFINITY);
         }
 
         #endregion
@@ -234,10 +205,10 @@ namespace Eduard.Tests.Extensions
             var jacPoint = curve.ToJacobian(modJacPoint);
 
             Assert.NotEqual(ECPoint3w.POINT_INFINITY, jacPoint);
-            Assert.Equal(modJacPoint.x, jacPoint.x);
+            Assert.Equal(modJacPoint.X, jacPoint.x);
 
-            Assert.Equal(modJacPoint.y, jacPoint.y);
-            Assert.Equal(modJacPoint.z, jacPoint.z);
+            Assert.Equal(modJacPoint.Y, jacPoint.y);
+            Assert.Equal(modJacPoint.Z, jacPoint.z);
         }
 
         [Fact]
@@ -284,9 +255,9 @@ namespace Eduard.Tests.Extensions
             BigInteger p = curve.field;
 
             Assert.NotEqual(ECPoint4w.POINT_INFINITY, modJacPoint);
-            Assert.Equal(jacPoint.x, modJacPoint.x);
-            Assert.Equal(jacPoint.y, modJacPoint.y);
-            Assert.Equal(jacPoint.z, modJacPoint.z);
+            Assert.Equal(jacPoint.x, modJacPoint.X);
+            Assert.Equal(jacPoint.y, modJacPoint.Y);
+            Assert.Equal(jacPoint.z, modJacPoint.Z);
 
             /* verify aZ^4 is correctly computed */
             var expectedZ2 = (jacPoint.z * jacPoint.z) % p;
@@ -315,9 +286,9 @@ namespace Eduard.Tests.Extensions
             BigInteger p = curve.field;
 
             Assert.NotEqual(ECPoint4w.POINT_INFINITY, modJacPoint);
-            Assert.Equal(jcPoint.x, modJacPoint.x);
-            Assert.Equal(jcPoint.y, modJacPoint.y);
-            Assert.Equal(jcPoint.z, modJacPoint.z);
+            Assert.Equal(jcPoint.x, modJacPoint.X);
+            Assert.Equal(jcPoint.y, modJacPoint.Y);
+            Assert.Equal(jcPoint.z, modJacPoint.Z);
 
             /* verify aZ^4 = a * (Z^2)^2 using precomputed Z^2 */
             var expectedZ4 = (jcPoint.z2 * jcPoint.z2) % p;
@@ -368,7 +339,7 @@ namespace Eduard.Tests.Extensions
         {
             var curve = TwistedEdwardsCurve.GetNamedCurve(
                 TwistedEdwardsCurveType.Edwards25519);
-            var identity = new ECPoint(0, 1);
+            var identity = ECPoint.POINT_INFINITY;
             var projPoint = curve.ToProjective(identity);
             Assert.Equal(ECPoint3.POINT_INFINITY, projPoint);
         }
@@ -774,9 +745,9 @@ namespace Eduard.Tests.Extensions
             var lambda4 = (lambda2 * lambda2) % p;
 
             var scaledPoint = new ECPoint4w(
-                (modJacPoint.x * lambda2) % p,
-                (modJacPoint.y * lambda3) % p,
-                (modJacPoint.z * lambda) % p,
+                (modJacPoint.X * lambda2) % p,
+                (modJacPoint.Y * lambda3) % p,
+                (modJacPoint.Z * lambda) % p,
                 (modJacPoint.aZ4 * lambda4) % p
             );
 

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -387,13 +387,13 @@ namespace Eduard.Tests.Extensions
             BigInteger p = curve.field;
 
             Assert.NotEqual(ECPoint4.POINT_INFINITY, extPoint);
-            Assert.Equal(G.GetAffineX(), extPoint.x);
+            Assert.Equal(G.GetAffineX(), extPoint.X);
 
-            Assert.Equal(G.GetAffineY(), extPoint.y);
-            Assert.Equal(1, extPoint.z);
+            Assert.Equal(G.GetAffineY(), extPoint.Y);
+            Assert.Equal(1, extPoint.Z);
 
             var expectedT = (G.GetAffineX() * G.GetAffineY()) % p;
-            Assert.Equal(expectedT, extPoint.t);
+            Assert.Equal(expectedT, extPoint.T);
         }
 
         [Fact]
@@ -449,21 +449,12 @@ namespace Eduard.Tests.Extensions
             /* test invalid point init via constructor */
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var invalidPoint = new ECPoint4(extPoint.x, 
-                    extPoint.y, extPoint.t, 0);
+                var invalidPoint = new ECPoint4(extPoint.X, 
+                    extPoint.Y, extPoint.T, 0);
             });
 
-            var invalidPoint = new ECPoint4(extPoint.x, 
-                extPoint.y, extPoint.t, extPoint.z);
-
-            /* mutate z coordinate externally */
-            invalidPoint.z = 0;
-
-            Assert.Throws<InvalidOperationException>(() => 
-                curve.ToAffine(invalidPoint));
-
-            var infinity = new ECPoint4(extPoint.x,
-                extPoint.y, 0, 0);
+            var infinity = new ECPoint4(extPoint.X,
+                extPoint.Y, 0, 0);
 
             /* right representation for point at infinity */
             var affinePoint = curve.ToAffine(infinity);
@@ -493,10 +484,10 @@ namespace Eduard.Tests.Extensions
             var expectedT = (projPoint.X * projPoint.Y) % p;
             var expectedZ = (projPoint.Z * projPoint.Z) % p;
 
-            Assert.Equal(expectedX, extPoint.x);
-            Assert.Equal(expectedY, extPoint.y);
-            Assert.Equal(expectedT, extPoint.t);
-            Assert.Equal(expectedZ, extPoint.z);
+            Assert.Equal(expectedX, extPoint.X);
+            Assert.Equal(expectedY, extPoint.Y);
+            Assert.Equal(expectedT, extPoint.T);
+            Assert.Equal(expectedZ, extPoint.Z);
         }
 
         [Fact]
@@ -520,10 +511,10 @@ namespace Eduard.Tests.Extensions
             var copyPoint = curve.GetPointCopy(projPoint);
             Assert.NotEqual(ECPoint4.POINT_INFINITY, copyPoint);
 
-            Assert.Equal(projPoint.X, copyPoint.x);
-            Assert.Equal(projPoint.Y, copyPoint.y);
-            Assert.Equal(projPoint.Z, copyPoint.z);
-            Assert.Equal(0, copyPoint.t);
+            Assert.Equal(projPoint.X, copyPoint.X);
+            Assert.Equal(projPoint.Y, copyPoint.Y);
+            Assert.Equal(projPoint.Z, copyPoint.Z);
+            Assert.Equal(0, copyPoint.T);
         }
 
         [Fact]
@@ -547,9 +538,9 @@ namespace Eduard.Tests.Extensions
             var projPoint = curve.ToProjective(extPoint);
             Assert.NotEqual(ECPoint3.POINT_INFINITY, projPoint);
 
-            Assert.Equal(extPoint.x, projPoint.X);
-            Assert.Equal(extPoint.y, projPoint.Y);
-            Assert.Equal(extPoint.z, projPoint.Z);
+            Assert.Equal(extPoint.X, projPoint.X);
+            Assert.Equal(extPoint.Y, projPoint.Y);
+            Assert.Equal(extPoint.Z, projPoint.Z);
         }
 
         [Fact]

--- a/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/ECPointExtensionsTests.cs
@@ -447,7 +447,7 @@ namespace Eduard.Tests.Extensions
         {
             var curve = TwistedEdwardsCurve.GetNamedCurve(
                 TwistedEdwardsCurveType.Edwards25519);
-            var identity = new ECPoint(0, 1);
+            var identity = ECPoint.POINT_INFINITY;
             var extPoint = curve.ToExtendedProjective(identity);
             Assert.Equal(ECPoint4.POINT_INFINITY, extPoint);
         }

--- a/UnitTests/Tests/Extensions/EllipticCurveExtensionsTests.cs
+++ b/UnitTests/Tests/Extensions/EllipticCurveExtensionsTests.cs
@@ -278,7 +278,7 @@ namespace Eduard.Tests.Extensions
         {
             var weiCurve = EllipticCurve.GetNamedCurve(WeiCurveType.Wei25519);
             var edwCurve = weiCurve.ToTwistedEdwardsCurve();
-            var point = edwCurve.ToWeierstrassPoint(new ECPoint(0, 1));
+            var point = edwCurve.ToWeierstrassPoint(ECPoint.POINT_INFINITY);
             Assert.Equal(ECPoint.POINT_INFINITY, point);
         }
 
@@ -327,7 +327,7 @@ namespace Eduard.Tests.Extensions
         {
             var weiCurve = EllipticCurve.GetNamedCurve(WeiCurveType.Wei25519);
             var edwCurve = weiCurve.ToTwistedEdwardsCurve();
-            var montyPoint = edwCurve.ToMontgomeryPoint(new ECPoint(0, 1));
+            var montyPoint = edwCurve.ToMontgomeryPoint(ECPoint.POINT_INFINITY);
             Assert.Equal(ECPoint.POINT_INFINITY, montyPoint);
         }
 

--- a/UnitTests/Tests/FiniteFields/PolyModTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolyModTests.cs
@@ -1,7 +1,6 @@
-﻿using Eduard.Security;
-using System;
+﻿using System;
+using Eduard.Security;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Eduard.Tests.FiniteFields
 {
@@ -12,7 +11,6 @@ namespace Eduard.Tests.FiniteFields
 
         static readonly BigInteger P256 = BigInteger.Pow(2, 256) - BigInteger.Pow(2, 224) +
                 BigInteger.Pow(2, 192) + BigInteger.Pow(2, 96) - 1;
-        static readonly BigInteger Ed25519 = BigInteger.Pow(2, 255) - 19;
 
         static Polynomial GetRandomPoly(int degree, BigInteger field)
         {

--- a/UnitTests/Tests/FiniteFields/PolyModTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolyModTests.cs
@@ -1,0 +1,877 @@
+﻿using Eduard.Security;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Eduard.Tests.FiniteFields
+{
+    [Collection("Sequential")]
+    public class PolyModTests
+    {
+        #region Primes Setup and Utilities
+
+        static readonly BigInteger P256 = BigInteger.Pow(2, 256) - BigInteger.Pow(2, 224) +
+                BigInteger.Pow(2, 192) + BigInteger.Pow(2, 96) - 1;
+        static readonly BigInteger Ed25519 = BigInteger.Pow(2, 255) - 19;
+
+        static Polynomial GetRandomPoly(int degree, BigInteger field)
+        {
+            Polynomial poly = new Polynomial(degree);
+
+            for (int k = 0; k <= degree; k++)
+                poly.coeffs[k] = SecureRandom.Range(0, field - 1);
+
+            return poly;
+        }
+
+        #endregion
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_ModulusNotInitialized_ThrowsInvalidOperationException()
+        {
+            var isInitializedField = typeof(PolyMod).GetField("isInitialized",
+                System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.NonPublic);
+
+            Assert.NotNull(isInitializedField);
+
+            var previousState = isInitializedField.GetValue(null);
+
+            try
+            {
+                isInitializedField.SetValue(null, false);
+                Polynomial.SetField(P256);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    var p = new PolyMod(5);
+                });
+            }
+            finally
+            {
+                isInitializedField.SetValue(null, previousState);
+            }
+        }
+
+        [Fact]
+        public void Constructor_Polynomial_AutomaticallyReduced()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            Polynomial p = new Polynomial(1, 0, 5);
+            PolyMod element = new PolyMod(p);
+
+            Assert.True(element.poly.Degree == 0);
+            Assert.True(element.GetCoeff(0) == 4);
+        }
+
+        [Fact]
+        public void Constructor_PolynomialDegreeLessThanModulus_ReturnsUnchanged()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            Polynomial p = new Polynomial(3, 7);
+
+            PolyMod element = new PolyMod(p);
+            Assert.True(element.poly.Degree == 1);
+
+            Assert.True(element.GetCoeff(1) == 3);
+            Assert.True(element.GetCoeff(0) == 7);
+        }
+
+        [Fact]
+        public void Constructor_Copy_IsIndependent()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod original = new PolyMod(new Polynomial(1, 2));
+            PolyMod copy = new PolyMod(original);
+
+            Assert.True(original == copy);
+
+            copy.poly.coeffs[0] = 99;
+            Assert.False(original == copy);
+        }
+
+        [Fact]
+        public void Constructor_ImplicitFromInt_ConstantElement()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod element = 42;
+
+            Assert.True(element.poly.Degree == 0);
+            Assert.True(element.GetCoeff(0) == 42);
+        }
+
+        [Fact]
+        public void Constructor_ImplicitFromBigInteger_ReducedConstant()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            BigInteger val = P256 + 10;
+            PolyMod element = val;
+
+            Assert.True(element.GetCoeff(0) == 10);
+        }
+
+        [Fact]
+        public void Constructor_ImplicitFromPolynomial_Works()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            Polynomial p = new Polynomial(2, 3);
+
+            PolyMod element = p;
+            Assert.True(element.poly == p);
+        }
+
+        #endregion
+
+        #region SetModulus Tests
+
+        [Fact]
+        public void SetModulus_ZeroPolynomial_ThrowsDivideByZeroException()
+        {
+            Polynomial.SetField(P256);
+            Assert.Throws<DivideByZeroException>(() =>
+                PolyMod.SetModulus(0));
+        }
+
+        [Fact]
+        public void SetModulus_NonZeroPolynomial_InitializesRing()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = new PolyMod(new Polynomial(1, 0, 5));
+
+            Assert.True(element.poly.Degree == 0);
+            Assert.True(element.GetCoeff(0) == 4);
+        }
+
+        [Fact]
+        public void SetModulus_ChangesModulus_NewModulusTakesEffect()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod e1 = new PolyMod(new Polynomial(1, 0, 0));
+            BigInteger val1 = e1.GetCoeff(0);
+
+            PolyMod.SetModulus(new Polynomial(1, 0, 2));
+            PolyMod e2 = new PolyMod(new Polynomial(1, 0, 0));
+
+            BigInteger val2 = e2.GetCoeff(0);
+            Assert.False(val1 == val2);
+        }
+
+        #endregion
+
+        #region GetCoeff Tests
+
+        [Fact]
+        public void GetCoeff_WithinDegree_ReturnsCoefficient()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = new PolyMod(new Polynomial(3, 7));
+
+            Assert.True(element.GetCoeff(1) == 3);
+            Assert.True(element.GetCoeff(0) == 7);
+        }
+
+        [Fact]
+        public void GetCoeff_BeyondDegree_ReturnsZero()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = new PolyMod(new Polynomial(3, 7));
+            Assert.True(element.GetCoeff(2) == 0);
+        }
+
+        [Fact]
+        public void GetCoeff_NegativeIndex_ThrowsIndexOutOfRange()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = 5;
+
+            Assert.Throws<IndexOutOfRangeException>(() =>
+                element.GetCoeff(-1));
+        }
+
+        #endregion
+
+        #region Arithmetic - Addition
+
+        [Fact]
+        public void Add_SameDegree_ReturnsSumReduced()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(3, 5));
+            PolyMod b = new PolyMod(new Polynomial(2, 1));
+            PolyMod sum = a + b;
+
+            Assert.True(sum.GetCoeff(1) == 5);
+            Assert.True(sum.GetCoeff(0) == 6);
+        }
+
+        [Fact]
+        public void Add_ResultExceedsModulusDegree_ReducedAutomatically()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(1, 0));
+            PolyMod b = new PolyMod(new Polynomial(1, 0));
+            PolyMod sum = a + b;
+
+            Assert.True(sum.GetCoeff(1) == 2);
+            Assert.True(sum.GetCoeff(0) == 0);
+        }
+
+        [Fact]
+        public void Add_WithZero_ReturnsOther()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod p = new PolyMod(new Polynomial(3, 2));
+            PolyMod zero = 0;
+
+            Assert.True(p + zero == p);
+            Assert.True(zero + p == p);
+        }
+
+        [Fact]
+        public void Add_Commutative()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(2, 3));
+
+            PolyMod b = new PolyMod(new Polynomial(5, 1));
+            Assert.True(a + b == b + a);
+        }
+
+        [Fact]
+        public void Add_TermCancellation_YieldsZero()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(5, 10));
+
+            PolyMod b = new PolyMod(new Polynomial(P256 - 5, P256 - 10));
+            Assert.True((a + b) == 0);
+        }
+
+        #endregion
+
+        #region Arithmetic - Subtraction
+
+        [Fact]
+        public void Sub_SameDegree_ReturnsDifference()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(5, 10));
+            PolyMod b = new PolyMod(new Polynomial(2, 4));
+            PolyMod diff = a - b;
+
+            Assert.True(diff.GetCoeff(1) == 3);
+            Assert.True(diff.GetCoeff(0) == 6);
+        }
+
+        [Fact]
+        public void Sub_Self_YieldsZero()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = new PolyMod(new Polynomial(4, 3));
+            Assert.True((p - p) == 0);
+        }
+
+        [Fact]
+        public void Sub_FromZero_Negation()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = new PolyMod(new Polynomial(5, 1));
+
+            PolyMod zero = 0;
+            PolyMod neg = zero - p;
+
+            Assert.True(neg.GetCoeff(1) == P256 - 5);
+            Assert.True(neg.GetCoeff(0) == P256 - 1);
+        }
+
+        #endregion
+
+        #region Arithmetic - Multiplication
+
+        [Fact]
+        public void Mul_ConstantElements_ReturnsProduct()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = 3, b = 4;
+            PolyMod prod = a * b;
+
+            Assert.True(prod.poly.Degree == 0);
+            Assert.True(prod.GetCoeff(0) == 12);
+        }
+
+        [Fact]
+        public void Mul_LinearElements_ProductReduced()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(1, 1));
+            PolyMod b = new PolyMod(new Polynomial(1, 2));
+
+            PolyMod prod = a * b;
+            Assert.True(prod.poly.Degree == 1);
+
+            Assert.True(prod.GetCoeff(1) == 3);
+            Assert.True(prod.GetCoeff(0) == 1);
+        }
+
+        [Fact]
+        public void Mul_Zero_ReturnsZero()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = new PolyMod(new Polynomial(5, 4));
+
+            Assert.True(p * 0 == 0);
+            Assert.True(0 * p == 0);
+        }
+
+        [Fact]
+        public void Mul_One_ReturnsOther()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = new PolyMod(new Polynomial(3, 7));
+
+            Assert.True(p * 1 == p);
+            Assert.True(1 * p == p);
+        }
+
+        [Fact]
+        public void Mul_Commutative()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(1, 2));
+
+            PolyMod b = new PolyMod(new Polynomial(3, 4));
+            Assert.True(a * b == b * a);
+        }
+
+        [Fact]
+        public void Mul_Distributive()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(1, 0));
+
+            PolyMod b = new PolyMod(new Polynomial(0, 2));
+            PolyMod c = 3;
+            Assert.True(a * (b + c) == a * b + a * c);
+        }
+
+        #endregion
+
+        #region Arithmetic - Scalar Division
+
+        [Fact]
+        public void ScalarDiv_ByConstant_ScaledByInverse()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(2, 4));
+            PolyMod q = a / 2;
+
+            Assert.True(q.GetCoeff(1) == 1);
+            Assert.True(q.GetCoeff(0) == 2);
+        }
+
+        [Fact]
+        public void ScalarDiv_ByZero_ThrowsDivideByZeroException()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(1, 2));
+            Assert.Throws<DivideByZeroException>(() => { var r = a / 0; });
+        }
+
+        #endregion
+
+        #region GCD Computation
+
+        [Fact]
+        public void Gcd_OfPolynomialWithModulus_ReturnsCorrect()
+        {
+            Polynomial.SetField(P256);
+            Polynomial modulus = new Polynomial(1, 0, 1);
+            PolyMod.SetModulus(modulus);
+
+            Polynomial g = PolyMod.Gcd(new Polynomial(1, 1));
+            Assert.True(g.Degree >= 1 || g == 1);
+        }
+
+        [Fact]
+        public void Gcd_CoprimePolynomial_ReturnsOne()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 2));
+            Polynomial g = PolyMod.Gcd(new Polynomial(1, 0));
+            Assert.True(g == 1);
+        }
+
+        #endregion
+
+        #region Modular Exponentiation
+
+        [Fact]
+        public void Pow_ExponentZero_ReturnsOne()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = 5;
+
+            PolyMod result = PolyMod.Pow(p, 0);
+            Assert.True(result == 1);
+        }
+
+        [Fact]
+        public void Pow_ExponentOne_ReturnsInput()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod p = new PolyMod(new Polynomial(3, 2));
+
+            PolyMod result = PolyMod.Pow(p, 1);
+            Assert.True(result == p);
+        }
+
+        [Fact]
+        public void Pow_SmallExponent_SmallModulus_Works()
+        {
+            Polynomial.SetField(17);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod X = new PolyMod(new Polynomial(1, 0));
+            PolyMod X2 = PolyMod.Pow(X, 2);
+
+            Assert.True(X2.GetCoeff(1) == 0);
+            Assert.True(X2.GetCoeff(0) == 16);
+
+            PolyMod X3 = PolyMod.Pow(X, 3);
+            Assert.True(X3.GetCoeff(1) == 16);
+
+            Assert.True(X3.GetCoeff(0) == 0);
+            Polynomial.SetField(P256);
+        }
+
+        [Fact]
+        public void Pow_FermatLittleTheorem_ForQuotientRing()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(3, 7));
+            PolyMod a2 = PolyMod.Pow(a, 2);
+
+            PolyMod a4 = PolyMod.Pow(a2, 2);
+            Assert.True(a4 == PolyMod.Pow(a, 4));
+        }
+
+        [Fact]
+        public void Pow_HigherDegreeModulus_ExponentiationConsistent()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 10, 12, 16, 20, 24 };
+            int k, degreesCount = degrees.Length;
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var modulus = GetRandomPoly(degrees[k], P256);
+                PolyMod.SetModulus(modulus);
+
+                var a = new PolyMod(GetRandomPoly(degrees[k] - 1, P256));
+                BigInteger exp = SecureRandom.Range(2, 100);
+
+                var result1 = PolyMod.Pow(a, exp);
+                var expected = (PolyMod)1;
+                var baseCopy = a;
+                var e = exp;
+
+                while (e > 0)
+                {
+                    if ((e & 1) == 1)
+                        expected = expected * baseCopy;
+                    baseCopy = baseCopy * baseCopy;
+                    e >>= 1;
+                }
+
+                Assert.True(result1 == expected,
+                    $"Degree {degrees[k]}: Pow result inconsistent with manual exponentiation");
+            }
+        }
+
+        [Fact]
+        public void Pow_ExponentiationProperty_PowAdditive()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 10, 12, 16, 20, 24 };
+            int k, degreesCount = degrees.Length;
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var modulus = GetRandomPoly(degrees[k], P256);
+                PolyMod.SetModulus(modulus);
+
+                var a = new PolyMod(GetRandomPoly(degrees[k] - 1, P256));
+                BigInteger e1 = SecureRandom.Range(1, 50);
+                BigInteger e2 = SecureRandom.Range(1, 50);
+
+                var p1 = PolyMod.Pow(a, e1);
+                var p2 = PolyMod.Pow(a, e2);
+                var pSum = PolyMod.Pow(a, e1 + e2);
+
+                Assert.True(p1 * p2 == pSum,
+                    $"Degree {degrees[k]}: a^e1 * a^e2 != a^(e1+e2)");
+            }
+        }
+
+        #endregion
+
+        #region Modular Composition (Brent-Kung)
+
+        [Fact]
+        public void Compose_IdentityPolynomial_IsNeutralElement()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod P = new PolyMod(new Polynomial(3, 7));
+            PolyMod X = new PolyMod(new Polynomial(1, 0));
+
+            var R = PolyMod.Compose(P, X);
+            Assert.True(R == P);
+
+            R = PolyMod.Compose(X, P);
+            Assert.True(R == P);
+        }
+
+        [Fact]
+        public void Compose_ConstantOuter_ReturnsConstant()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod c = 5;
+
+            PolyMod Q = new PolyMod(new Polynomial(2, 3));
+            PolyMod result = PolyMod.Compose(c, Q);
+            Assert.True(result == c);
+        }
+
+        [Fact]
+        public void Compose_LinearIntoLinear_ReturnsCorrect()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod P = new PolyMod(new Polynomial(3, 2));
+
+            PolyMod Q = new PolyMod(new Polynomial(4, 1));
+            PolyMod result = PolyMod.Compose(P, Q);
+
+            Assert.True(result.GetCoeff(1) == 12);
+            Assert.True(result.GetCoeff(0) == 5);
+        }
+
+        [Fact]
+        public void Compose_QuadraticIntoLinear_ModularReductionApplied()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod P = new PolyMod(new Polynomial(1, 1, 1));
+
+            PolyMod X = new PolyMod(new Polynomial(1, 0));
+            PolyMod result = PolyMod.Compose(P, X);
+
+            Assert.True(result.GetCoeff(1) == 1);
+            Assert.True(result.GetCoeff(0) == 0);
+        }
+
+        [Fact]
+        public void Compose_HigherDegreeModulus_BrentKungConsistent()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 10, 12, 16, 20, 24 };
+            int k, degreesCount = degrees.Length;
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var modulus = GetRandomPoly(degrees[k], P256);
+                PolyMod.SetModulus(modulus);
+
+                var X = new PolyMod(new Polynomial(1, 0));
+                var P = new PolyMod(GetRandomPoly(degrees[k] - 1, P256));
+
+                var R = PolyMod.Compose(P, X);
+                Assert.True(R == P,
+                    $"Degree {degrees[k]}: Compose(P, X) != P");
+
+                R = PolyMod.Compose(X, P);
+                Assert.True(R == P,
+                    $"Degree {degrees[k]}: Compose(X, P) != P");
+            }
+        }
+
+        [Fact]
+        public void Compose_FrobeniusEndomorphism_PropertyHolds()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 10, 12, 16, 20, 24 };
+            int k, degreesCount = degrees.Length;
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var modulus = GetRandomPoly(degrees[k], P256);
+                PolyMod.SetModulus(modulus);
+
+                var X = new PolyMod(new Polynomial(1, 0));
+                var XP = PolyMod.Pow(X, P256);
+
+                var XP2 = PolyMod.Compose(XP, XP);
+                var XPP = PolyMod.Pow(XP, P256);
+
+                Assert.True(XP2 == XPP,
+                    $"Degree {degrees[k]}: Frobenius composition property failed");
+            }
+        }
+
+        [Fact]
+        public void Compose_WithPowerMap_MatchesDirectExponentiation()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 10, 12, 16, 20, 24 };
+            int k, degreesCount = degrees.Length;
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var modulus = GetRandomPoly(degrees[k], P256);
+                PolyMod.SetModulus(modulus);
+
+                var X = new PolyMod(new Polynomial(1, 0));
+                var F = new PolyMod(GetRandomPoly(degrees[k] - 1, P256));
+
+                BigInteger exp = SecureRandom.Range(2, 20);
+                var Xe = PolyMod.Pow(X, exp);
+
+                var composed = PolyMod.Compose(F, Xe);
+                PolyMod expected = 0;
+
+                for (int i = 0; i <= F.poly.Degree; i++)
+                {
+                    var coeff = F.poly.GetCoeff(i);
+                    if (coeff != 0)
+                    {
+                        var term = PolyMod.Pow(Xe, i);
+                        expected = expected + (PolyMod)(coeff * term.poly);
+                    }
+                }
+
+                Assert.True(composed == expected,
+                    $"Degree {degrees[k]}: Compose(F, X^e) != direct evaluation");
+            }
+        }
+
+        #endregion
+
+        #region Evaluation (F)
+
+        [Fact]
+        public void F_ConstantElement_ReturnsConstant()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod c = 7;
+
+            BigInteger val = c.F(5);
+            Assert.True(val == 7);
+        }
+
+        [Fact]
+        public void F_LinearElement_EvaluatesCorrectly()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = new PolyMod(new Polynomial(3, 2));
+
+            BigInteger val = element.F(5);
+            Assert.True(val == 17);
+        }
+
+        [Fact]
+        public void F_OutsideFieldRange_ThrowsArgumentOutOfRange()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod element = 1;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                element.F(P256));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                element.F(-1));
+        }
+
+        #endregion
+
+        #region Equality and HashCode
+
+        [Fact]
+        public void Equality_SameElement_ReturnsTrue()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(1, 2));
+            PolyMod b = new PolyMod(new Polynomial(1, 2));
+
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.True(a.Equals(b));
+        }
+
+        [Fact]
+        public void Equality_DifferentElements_ReturnsFalse()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+
+            PolyMod a = new PolyMod(new Polynomial(1, 0));
+            PolyMod b = 1;
+
+            Assert.False(a == b);
+            Assert.True(a != b);
+        }
+
+        [Fact]
+        public void Equality_WithNullObject_ReturnsFalse()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = 1;
+
+            object obj = null;
+            Assert.False(a.Equals(obj));
+        }
+
+        [Fact]
+        public void GetHashCode_SameElement_SameHash()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(3, 2, 1));
+
+            PolyMod b = new PolyMod(new Polynomial(3, 2, 1));
+            Assert.True(a.GetHashCode() == b.GetHashCode());
+        }
+
+        #endregion
+
+        #region Cryptographic Property Tests
+
+        [Fact]
+        public void RingOperations_FormAbelianGroupUnderAddition()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(3, 7));
+
+            PolyMod b = new PolyMod(new Polynomial(1, 4));
+            PolyMod c = new PolyMod(new Polynomial(2, 5));
+            PolyMod zero = 0;
+
+            Assert.True((a + b) + c == a + (b + c));
+            Assert.True(a + zero == a);
+
+            Assert.True(a + (zero - a) == 0);
+            Assert.True(a + b == b + a);
+        }
+
+        [Fact]
+        public void RingOperations_FormMonoidUnderMultiplication()
+        {
+            Polynomial.SetField(P256);
+            PolyMod.SetModulus(new Polynomial(1, 0, 1));
+            PolyMod a = new PolyMod(new Polynomial(3, 7));
+
+            PolyMod b = new PolyMod(new Polynomial(1, 4));
+            PolyMod c = new PolyMod(new Polynomial(2, 5));
+            PolyMod one = 1;
+
+            Assert.True((a * b) * c == a * (b * c));
+            Assert.True(a * one == a);
+            Assert.True(a * b == b * a);
+        }
+
+        [Fact]
+        public void FrobeniusEndomorphism_OnSplittingPolynomial_ReturnsIdentity()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 6, 8, 10 };
+            int count = degrees.Length;
+            int k;
+
+            for (k = 0; k < count; k++)
+            {
+                int chosenDegree = degrees[k];
+                var roots = new List<BigInteger>();
+                int counter = chosenDegree;
+
+                while (counter > 0)
+                {
+                    var root = SecureRandom.Range(1, P256 - 1);
+                    roots.Add(root);
+                    counter--;
+                }
+
+                Polynomial modulus = 1;
+
+                for (int i = 0; i < roots.Count; i++)
+                {
+                    BigInteger negRoot = P256 - roots[i];
+                    modulus *= new Polynomial(1, negRoot);
+                }
+
+                PolyMod.SetModulus(modulus);
+                PolyMod X = new PolyMod(new Polynomial(1, 0));
+
+                PolyMod XP = PolyMod.Pow(X, P256);
+                Assert.True(XP == X,
+                    $"Degree {chosenDegree}: Frobenius not identity on splitting polynomial");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -28,7 +28,7 @@ namespace Eduard.Tests.FiniteFields
             int k, rootsCount = roots.Count;
             Polynomial result = 1;
 
-            for (k = 1; k < rootsCount; k++)
+            for (k = 0; k < rootsCount; k++)
             {
                 BigInteger a = field - roots[k];
                 Polynomial Pa = new Polynomial(1, a);
@@ -694,16 +694,42 @@ namespace Eduard.Tests.FiniteFields
         }
 
         [Fact]
+        public void Horner_HighDegree_Poly_EvaluatesCorrectly()
+        {
+            Polynomial.SetField(P256);
+            int[] rootsCount = new int[] { 3, 6, 8, 12, 16 };
+
+            int len = rootsCount.Length;
+            int j, k;
+
+            for(j = 0; j < len; j++)
+            {
+                var roots = GenRoots(rootsCount[j], P256);
+                var G = GetPolyFromRoots(roots, P256);
+                int countRoots = roots.Count;
+
+                for(k = 0; k < countRoots; k++)
+                {
+                    var val = Polynomial.Horner(G, roots[k]);
+                    Assert.True(val == 0);
+
+                    var linearPoly = new Polynomial(1, -roots[k]);
+                    G /= linearPoly;
+                }
+            }
+        }
+
+        [Fact]
         public void Horner_OutsideFieldRange_ThrowsArgumentOutOfRange()
         {
             Polynomial.SetField(P256);
-            Polynomial p = 1;
+            Polynomial G = 1;
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                Polynomial.Horner(p, P256));
+                Polynomial.Horner(G, P256));
 
             Assert.Throws<ArgumentOutOfRangeException>(() =>
-                Polynomial.Horner(p, -1));
+                Polynomial.Horner(G, -1));
         }
 
         #endregion

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -58,6 +58,20 @@ namespace Eduard.Tests.FiniteFields
         #region Constructor Tests
 
         [Fact]
+        public void Constructor_Default_InitializesToZeroPolynomial()
+        {
+            Polynomial.SetField(P256);
+            var poly = new Polynomial();
+
+            Assert.True(poly == 0);
+            Assert.Equal(poly.GetCoeff(0), 0);
+
+            Assert.Throws<IndexOutOfRangeException>(() =>
+                poly.GetCoeff(-1));
+            Assert.Equal(poly.GetCoeff(1), 0);
+        }
+
+        [Fact]
         public void Constructor_Degree_CreatesZeroPolynomial()
         {
             Polynomial.SetField(P256);
@@ -94,8 +108,30 @@ namespace Eduard.Tests.FiniteFields
         public void Constructor_Params_ReducesModuloField()
         {
             Polynomial.SetField(P256);
-            Polynomial p = 20;
-            Assert.True(p.GetCoeff(0) == 20 % P256);
+            var coeffs = new BigInteger[10];
+            int j, k, val = -2;
+
+            int degree = 9;
+            int sign = -1;
+            coeffs[0] = 1;
+
+            for (j = 1; j <= degree; j++)
+            {
+                coeffs[j] = val;
+                val = sign * (Math.Abs(val) + 1);
+                sign *= -1;
+            }
+
+            var p = new Polynomial(coeffs);
+            var halfN = P256 >> 1;
+
+            for(k = 0; k <= degree; k++)
+            {
+                var coeff = p.GetCoeff(degree - k);
+                var coeffValue = (coeff > halfN) ?
+                    coeff - P256 : coeff;
+                Assert.True(coeffValue == coeffs[k]);
+            }
         }
 
         [Fact]
@@ -134,8 +170,10 @@ namespace Eduard.Tests.FiniteFields
         {
             Polynomial.SetField(P256);
             Polynomial p = 42;
+
             Assert.True(p.Degree == 0);
             Assert.True(p.GetCoeff(0) == 42);
+            Assert.True(p.GetCoeff(1) == 0);
         }
 
         [Fact]
@@ -146,6 +184,7 @@ namespace Eduard.Tests.FiniteFields
 
             Polynomial p = val;
             Assert.True(p.GetCoeff(0) == 10);
+            Assert.True(p.GetCoeff(1) == 0);
         }
 
         #endregion
@@ -624,16 +663,10 @@ namespace Eduard.Tests.FiniteFields
 
             var XP = (XP2 * XP2) % modulus;
             XP = (XP * X) % modulus;
-            var factor = Polynomial.Gcd(XP - X, modulus);
 
+            var factor = Polynomial.Gcd(XP - X, modulus);
             var remainder = modulus % factor;
             Assert.True(remainder == 0);
-
-            if (factor != 1)
-            {
-                Polynomial quotient = modulus / factor;
-                Assert.Equal(modulus, quotient * factor);
-            }
         }
 
         #endregion

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -1120,6 +1120,28 @@ namespace Eduard.Tests.FiniteFields
         }
 
         [Fact]
+        public void Invmodxn_RandomDegrees_ProductModxnEqualsOne()
+        {
+            Polynomial.SetField(P256);
+            int[] degrees = { 8, 10, 12, 16, 20 };
+            int degreesCount = degrees.Length, k;
+
+            for(k = 0; k < degreesCount; k++)
+            {
+                int currentDegree = degrees[k];
+                int degree = (int)SecureRandom.Range(
+                    1, currentDegree - 1);
+
+                var P = GetRandomPoly(degree, P256);
+                var Q = Polynomial.Invmodxn(P, currentDegree);
+
+                var R = Polynomial.Modxn(P * Q, currentDegree);
+                Assert.True(R == 1);
+            }
+
+        }
+
+        [Fact]
         public void Invmodxn_ZeroPolynomial_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>(() =>

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -825,6 +825,20 @@ namespace Eduard.Tests.FiniteFields
         }
 
         [Fact]
+        public void Compose_IdentityPolynomial_IsNeutralElement()
+        {
+            Polynomial.SetField(P256);
+            var P = GetRandomPoly(16, P256);
+            var X = new Polynomial(1, 0);
+
+            var R = Polynomial.Compose(P, X);
+            Assert.True(R == P);
+
+            R = Polynomial.Compose(X, P);
+            Assert.True(R == P);
+        }
+
+        [Fact]
         public void Compose_Modular_Basic()
         {
             Polynomial.SetField(P256);
@@ -836,6 +850,29 @@ namespace Eduard.Tests.FiniteFields
 
             Assert.True(res.GetCoeff(1) == 1);
             Assert.True(res.GetCoeff(0) == 2);
+        }
+
+        [Fact]
+        public void Compose_IdentityNeutral_AndFrobeniusEndomorphism_AreConsistent()
+        {
+            Polynomial.SetField(P256);
+            var M = GetRandomPoly(32, P256);
+
+            var X = new Polynomial(1, 0);
+            var P = Polynomial.Pow(X, P256, M);
+
+            /* check if neutral element for modular composition works */
+            var R = Polynomial.Compose(P, X);
+            Assert.True(R == P);
+
+            R = Polynomial.Compose(X, P);
+            Assert.True(R == P);
+
+            /* check quadratic extension for Frobenius map */
+            R = Polynomial.Compose(P, P, M);
+
+            var XPP = Polynomial.Pow(P, P256, M);
+            Assert.True(R == XPP);
         }
 
         #endregion

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -411,6 +411,43 @@ namespace Eduard.Tests.FiniteFields
             Assert.True(prod.GetCoeff(0) == 1);
         }
 
+        [Fact]
+        public void Mul_HighDegree_MatchesDivisionCheck()
+        {
+            int[] degrees = { 64, 96, 128, 256, 512 };
+            int k, degreesCount = degrees.Length;
+            Polynomial.SetField(Ed25519);
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                var P = GetRandomPoly(degrees[k], Ed25519);
+                var degreeDelta = (int)SecureRandom.Range(0, degrees[k] >> 2);
+                var Q = GetRandomPoly(degrees[k] + degreeDelta, Ed25519);
+
+                var res = P * Q;
+                var quo = res / Q;
+                Assert.Equal(quo, P);
+                
+            }
+        }
+
+        [Fact]
+        public void Square_HighDegree_MatchesMultiplicationBySelf()
+        {
+            int[] degrees = { 64, 96, 128, 256, 512 };
+            int k, degreesCount = degrees.Length;
+            Polynomial.SetField(Ed25519);
+
+            for(k = 0; k < degreesCount; k++)
+            {
+                var P = GetRandomPoly(degrees[k], Ed25519);
+                var squaredP = P * P;
+
+                var quo = squaredP / P;
+                Assert.Equal(quo, P);
+            }
+        }
+
         #endregion
 
         #region Arithmetic - Division and Modulus
@@ -494,6 +531,31 @@ namespace Eduard.Tests.FiniteFields
             Polynomial a = new Polynomial(1, 1);
             Polynomial b = new Polynomial(1, 1);
             Assert.True(((a * b) % a) == 0);
+        }
+
+        [Fact]
+        public void Reduce_HighDegree_MatchesModuloOperator()
+        {
+            int[] degrees = { 80, 96, 128, 256, 512 };
+            int k, degreesCount = degrees.Length;
+            Polynomial.SetField(Ed25519);
+
+            for (k = 0; k < degreesCount; k++)
+            {
+                int degm = degrees[k];
+                int maxn = 2 * (degm - 1);
+                int minn = degm + 64;
+
+                var remDegree = (int)SecureRandom.Range(minn, maxn);
+                var P = GetRandomPoly(remDegree, Ed25519);
+
+                var M = GetRandomPoly(degrees[k], Ed25519);
+                Polynomial.SetPolyMod(M);
+
+                var R = Polynomial.Reduce(P, M);
+                var rem = P % M;
+                Assert.True(R == rem);
+            }
         }
 
         [Fact]

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -646,24 +646,51 @@ namespace Eduard.Tests.FiniteFields
         public void Horner_ZeroPolynomial_ReturnsZero()
         {
             Polynomial.SetField(P256);
-            Assert.True(Polynomial.Horner(0, 5) == 0);
+            Polynomial G = 0;
+            BigInteger eval = Polynomial.Horner(G, 5);
+            Assert.True(eval == 0);
+        }
+
+        [Fact]
+        public void Horner_OnePolynomial_ReturnOne()
+        {
+            Polynomial.SetField(P256);
+            Polynomial G = 1;
+
+            BigInteger eval = Polynomial.Horner(G, 3);
+            Assert.True(eval == 1);
         }
 
         [Fact]
         public void Horner_Constant_ReturnsConstant()
         {
             Polynomial.SetField(P256);
-            Polynomial p = 7;
-            Assert.True(Polynomial.Horner(p, 10) == 7);
+            Polynomial G = 7;
+            BigInteger eval = Polynomial.Horner(G, 10);
+            Assert.True(eval == 7);
         }
 
         [Fact]
         public void Horner_Linear_EvaluatesCorrectly()
         {
             Polynomial.SetField(P256);
-            Polynomial p = new Polynomial(3, 2);
-            BigInteger val = Polynomial.Horner(p, 5);
-            Assert.True(val == 17 % P256);
+            Polynomial G = new Polynomial(3, 2);
+            BigInteger val = Polynomial.Horner(G, 5);
+            Assert.True(val == (17 % P256));
+        }
+
+        [Fact]
+        public void Horner_Quadratic_EvaluatesCorrectly()
+        {
+            Polynomial.SetField(P256);
+            Polynomial p = new Polynomial(1, -11, 24);
+
+            /* check if roots cancel the polynomial equation */
+            BigInteger val = Polynomial.Horner(p, 3);
+            Assert.True(val == 0);
+
+            val = Polynomial.Horner(p, 8);
+            Assert.True(val == 0);
         }
 
         [Fact]

--- a/UnitTests/Tests/FiniteFields/PolynomialTests.cs
+++ b/UnitTests/Tests/FiniteFields/PolynomialTests.cs
@@ -566,6 +566,17 @@ namespace Eduard.Tests.FiniteFields
         }
 
         [Fact]
+        public void PowMod_ZeroModularBaseZeroExponent_ThrowsArithmeticException()
+        {
+            Assert.Throws<ArithmeticException>(() => {
+                Polynomial.SetField(P256);
+                var modulus = GetRandomPoly(16, P256);
+                var G = new Polynomial(modulus);
+                Polynomial.Pow(G, 0, modulus);
+            });
+        }
+
+        [Fact]
         public void PowMod_ExponentZero_ReturnsOne()
         {
             Polynomial.SetField(P256);
@@ -600,6 +611,29 @@ namespace Eduard.Tests.FiniteFields
 
             Assert.True(res.GetCoeff(0) == 15);
             Polynomial.SetField(P256);
+        }
+
+        [Fact]
+        public void PowMod_LargeModulus_UseSlidingWindowMethod()
+        {
+            Polynomial.SetField(P256);
+            var modulus = GetRandomPoly(16, P256);
+
+            Polynomial X = new Polynomial(1, 0);
+            var XP2 = Polynomial.Pow(X, (P256 - 1) >> 1, modulus);
+
+            var XP = (XP2 * XP2) % modulus;
+            XP = (XP * X) % modulus;
+            var factor = Polynomial.Gcd(XP - X, modulus);
+
+            var remainder = modulus % factor;
+            Assert.True(remainder == 0);
+
+            if (factor != 1)
+            {
+                Polynomial quotient = modulus / factor;
+                Assert.Equal(modulus, quotient * factor);
+            }
         }
 
         #endregion

--- a/UnitTests/Tests/Points/AffinePointTests.cs
+++ b/UnitTests/Tests/Points/AffinePointTests.cs
@@ -1,10 +1,10 @@
-﻿using Eduard.Security.Primitives;
-using System;
+﻿using System;
+using Eduard.Security.Primitives;
 using System.Collections.Generic;
 
-namespace Eduard.Tests.Curves
+namespace Eduard.Tests.Points
 {
-    public class PointTests
+    public class AffinePointTests
     {
         #region Constructor Tests
 
@@ -162,7 +162,6 @@ namespace Eduard.Tests.Curves
         {
             var infinity1 = ECPoint.POINT_INFINITY;
             var infinity2 = ECPoint.POINT_INFINITY;
-
             Assert.Equal(infinity1, infinity2);
             Assert.True(infinity1 == infinity2);
         }
@@ -369,7 +368,6 @@ namespace Eduard.Tests.Curves
 
             var point = new ECPoint(x, y);
             Assert.True(point.Equals(point));
-            Assert.True(point == point);
         }
 
         [Fact]
@@ -677,8 +675,8 @@ namespace Eduard.Tests.Curves
             set.Add(p1);
             Assert.Single(set);
 
-            Assert.True(set.Contains(p2));
-            Assert.False(set.Contains(p3));
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
         }
 
         [Fact]
@@ -693,7 +691,7 @@ namespace Eduard.Tests.Curves
             set.Add(inf1);
 
             Assert.Single(set);
-            Assert.True(set.Contains(inf2));
+            Assert.Contains(inf2, set);
         }
 
         [Fact]
@@ -721,7 +719,7 @@ namespace Eduard.Tests.Curves
             var p2 = new ECPoint(x, y);
 
             list.Add(p1);
-            Assert.True(list.Contains(p2));
+            Assert.Contains(p2, list);
         }
 
         [Fact]
@@ -732,7 +730,7 @@ namespace Eduard.Tests.Curves
             var inf2 = ECPoint.POINT_INFINITY;
 
             list.Add(inf1);
-            Assert.True(list.Contains(inf2));
+            Assert.Contains(inf2, list);
         }
 
         #endregion

--- a/UnitTests/Tests/Points/ChudnovskiPointTests.cs
+++ b/UnitTests/Tests/Points/ChudnovskiPointTests.cs
@@ -1,0 +1,1449 @@
+﻿using System;
+using Eduard.Security.Primitives;
+using System.Collections.Generic;
+
+namespace Eduard.Tests.Points
+{
+    public class ChudnovskiPointTests
+    {
+        #region Constructor Tests
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithValidCoordinates_CreatesJacobianChudnovskyPoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNonUnitZ_CreatesValidPoint()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            BigInteger z2 = 4;
+            BigInteger z3 = 8;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithZZeroAndZ2Z3Zero_CreatesInfinityPoint()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithZZeroAndNonZeroZ2_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 5;
+            BigInteger z3 = 0;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ECPoint5w(x, y, z, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithZZeroAndNonZeroZ3_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 5;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ECPoint5w(x, y, z, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithZZeroAndNonZeroZ2Z3_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 5;
+            BigInteger z3 = 10;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ECPoint5w(x, y, z, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(null, y, z, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(x, null, z, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNullZ_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(x, y, null, z2, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNullZ2_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger z3 = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(x, y, z, null, z3));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithNullZ3_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger z2 = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(x, y, z, z2, null));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithAllNullCoordinates_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint5w(null, null, null, null, null));
+        }
+
+        [Fact]
+        public void ECPoint5w_Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger z = 1;
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_HasZEqualToZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_HasZ2EqualToZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z2);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_HasZ3EqualToZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_NormalizedCoordinates_ReturnsOneOneZeroZeroZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
+
+            Assert.Equal(0, infinity.Z2);
+            Assert.Equal(0, infinity.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint5w.POINT_INFINITY;
+            var infinity2 = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
+
+        [Fact]
+        public void ECPoint5w_PointInfinity_AnyPointWithZZeroZ2ZeroZ3Zero_IsInfinity()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger z2 = 0;
+
+            BigInteger z3 = 0;
+            var point = new ECPoint5w(x, 
+                y, z, z2, z3);
+
+            Assert.True(point.IsInfinity);
+            Assert.Equal(0, point.Z);
+
+            Assert.Equal(0, point.Z2);
+            Assert.Equal(0, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint5w);
+            Assert.True(defaultPoint.IsInfinity);
+            Assert.Equal(1, defaultPoint.X);
+
+            Assert.Equal(1, defaultPoint.Y);
+            Assert.Equal(0, defaultPoint.Z);
+
+            Assert.Equal(0, defaultPoint.Z2);
+            Assert.Equal(0, defaultPoint.Z3);
+        }
+
+        #endregion
+
+        #region Coordinate Accessor Tests
+
+        [Fact]
+        public void ECPoint5w_GetX_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(x, point.X);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetX_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetX_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(1, point.X);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            BigInteger z2 = 9;
+            BigInteger z3 = 27;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var result1 = point.X;
+
+            var result2 = point.X;
+            var result3 = point.X;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(y, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(1, infinity.Y);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(1, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            BigInteger z2 = 9;
+            BigInteger z3 = 27;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var result1 = point.Y;
+
+            var result2 = point.Y;
+            var result3 = point.Y;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            BigInteger z2 = 4;
+            BigInteger z3 = 8;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 7;
+
+            BigInteger z2 = 49;
+            BigInteger z3 = 343;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var result1 = point.Z;
+
+            var result2 = point.Z;
+            var result3 = point.Z;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ2_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            BigInteger z2 = 4;
+            BigInteger z3 = 8;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(z2, point.Z2);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ2_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z2);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ2_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(0, point.Z2);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ2_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            BigInteger z2 = 9;
+            BigInteger z3 = 27;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var result1 = point.Z2;
+
+            var result2 = point.Z2;
+            var result3 = point.Z2;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ3_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            BigInteger z2 = 4;
+            BigInteger z3 = 8;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ3_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ3_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(0, point.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetZ3_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            BigInteger z2 = 9;
+            BigInteger z3 = 27;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var result1 = point.Z3;
+
+            var result2 = point.Z3;
+            var result3 = point.Z3;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint5w_CoordinateAccessors_WithLargeZPowers_ReturnCorrectValues()
+        {
+            BigInteger x = 100;
+            BigInteger y = 200;
+            BigInteger z = 10;
+
+            BigInteger z2 = 100;
+            BigInteger z3 = 1000;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(z2, point.Z2);
+            Assert.Equal(z3, point.Z3);
+        }
+
+        #endregion
+
+        #region Point Validity Tests
+
+        [Fact]
+        public void ECPoint5w_IsInfinity_FinitePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint5w.POINT_INFINITY.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_IsInfinity_NonZeroZ_ReturnsFalse()
+        {
+            var zValues = new[] { 1, 2, 3, 100 };
+
+            foreach (var zVal in zValues)
+            {
+                BigInteger x = 5;
+                BigInteger y = 10;
+                BigInteger z = zVal;
+
+                BigInteger z2 = zVal * zVal;
+                BigInteger z3 = zVal * zVal * zVal;
+
+                var point = new ECPoint5w(x, y, z, z2, z3);
+                Assert.False(point.IsInfinity);
+            }
+        }
+
+        [Fact]
+        public void ECPoint5w_IsInfinity_ZeroZAndZeroZ2Z3_AlwaysReturnsTrue()
+        {
+            var coordinates = new[]
+            {
+                (1, 1), (0, 0), (-1, -1), 
+                (42, 100), (999, 888)
+            };
+
+            foreach (var (xVal, yVal) in coordinates)
+            {
+                BigInteger x = xVal;
+                BigInteger y = yVal;
+                BigInteger z = 0;
+
+                BigInteger z2 = 0;
+                BigInteger z3 = 0;
+
+                var point = new ECPoint5w(x, y, z, z2, z3);
+                Assert.True(point.IsInfinity);
+            }
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void ECPoint5w_Equals_SameCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+
+            Assert.True(point1.Equals(point2));
+            Assert.True(point1 == point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point.Equals(point));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint5w.POINT_INFINITY;
+            var inf2 = ECPoint5w.POINT_INFINITY;
+
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0, z21 = 0, z31 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0, z22 = 0, z32 = 0;
+
+            var off1 = new ECPoint5w(x1, y1, z1, z21, z31);
+            var off2 = new ECPoint5w(x2, y2, z2, z22, z32);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_SameProjectiveCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            BigInteger z2 = 4;
+            BigInteger z3 = 8;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger z = 1;
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x1, y, z, z2, z3);
+            var point2 = new ECPoint5w(x2, y, z, z2, z3);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y1, z, z2, z3);
+            var point2 = new ECPoint5w(x, y2, z, z2, z3);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentZCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            BigInteger z21 = 1, z31 = 1;
+            BigInteger z22 = 4, z32 = 8;
+
+            var point1 = new ECPoint5w(x, y, z1, z21, z31);
+            var point2 = new ECPoint5w(x, y, z2, z22, z32);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentZ2Coordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z21 = 1, z22 = 2;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z21, z3);
+            var point2 = new ECPoint5w(x, y, z, z22, z3);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentZ3Coordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z31 = 1, z32 = 2;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z31);
+            var point2 = new ECPoint5w(x, y, z, z2, z32);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1, z21 = 1, z31 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 2, z22 = 4, z32 = 8;
+            var point1 = new ECPoint5w(x1, y1, z1, z21, z31);
+
+            var point2 = new ECPoint5w(x2, y2, z2, z22, z32);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            var infinity = ECPoint5w.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint5w(x, y, 1, 1, 1);
+            var offCurve = new ECPoint5w(x, y, 0, 0, 0);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void ECPoint5w_Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void ECPoint5w_EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var p1 = new ECPoint5w(x, y, z, z2, z3);
+            var p2 = new ECPoint5w(x, y, z, z2, z3);
+            var p3 = new ECPoint5w(x, y, z, z2, z3);
+
+            Assert.True(p1 == p2);
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void ECPoint5w_InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var p1 = new ECPoint5w(x, y, z, z2, z3);
+            var p2 = new ECPoint5w(x, y, z, z2, z3);
+            var p3 = new ECPoint5w(x + 1, y, z, z2, z3);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
+        }
+
+        #endregion
+
+        #region GetHashCode Tests
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_SamePoints_HaveSameHashCode()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x, y, z, z2, z3);
+
+            Assert.Equal(point1.GetHashCode(), 
+                point2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0, z21 = 0, z31 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0, z22 = 0, z32 = 0;
+
+            var off1 = new ECPoint5w(x1, y1, z1, z21, z31);
+            var off2 = new ECPoint5w(x2, y2, z2, z22, z32);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), off2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point1 = new ECPoint5w(x, y, z, z2, z3);
+            var point2 = new ECPoint5w(x + 1, y, z, z2, z3);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_DifferentZPowers_ProduceDifferentHashes()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z21 = 1, z31 = 1;
+            BigInteger z22 = 4, z32 = 8;
+
+            var point1 = new ECPoint5w(x, y, z, z21, z31);
+            var point2 = new ECPoint5w(x, y, z, z22, z32);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ECPoint5w_GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1, -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    foreach (var zVal in new[] { 1, 2, 3 })
+                    {
+                        BigInteger x = xVal;
+                        BigInteger y = yVal;
+                        BigInteger z = zVal;
+
+                        BigInteger z2 = zVal * zVal;
+                        BigInteger z3 = zVal * zVal * zVal;
+
+                        var point1 = new ECPoint5w(x, y, z, z2, z3);
+                        var point2 = new ECPoint5w(x, y, z, z2, z3);
+
+                        Assert.Equal(point1.GetHashCode(), 
+                            point2.GetHashCode());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Collection Integration Tests
+
+        [Fact]
+        public void ECPoint5w_HashSet_HandlesJacobianChudnovskyPointsCorrectly()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1, z21 = 1, z31 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 1, z22 = 1, z32 = 1;
+
+            var set = new HashSet<ECPoint5w>();
+            var p1 = new ECPoint5w(x1, y1, z1, z21, z31);
+
+            var p2 = new ECPoint5w(x1, y1, z1, z21, z31);
+            var p3 = new ECPoint5w(x2, y2, z2, z22, z32);
+
+            set.Add(p1);
+            Assert.Single(set);
+
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
+        }
+
+        [Fact]
+        public void ECPoint5w_HashSet_DifferentZPowers_TreatedAsDifferent()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            BigInteger z21 = 4, z31 = 8;
+            BigInteger z22 = 5, z32 = 10;
+
+            var set = new HashSet<ECPoint5w>();
+            var p1 = new ECPoint5w(x, y, z, z21, z31);
+            var p2 = new ECPoint5w(x, y, z, z22, z32);
+
+            set.Add(p1); set.Add(p2);
+            Assert.Equal(2, set.Count);
+        }
+
+        [Fact]
+        public void ECPoint5w_HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint5w>();
+            var inf1 = ECPoint5w.POINT_INFINITY;
+
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var inf2 = new ECPoint5w(x, y, z, z2, z3);
+            set.Add(inf1);
+
+            Assert.Single(set);
+            Assert.Contains(inf2, set);
+        }
+
+        [Fact]
+        public void ECPoint5w_Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var dict = new Dictionary<ECPoint5w, string>();
+            var p1 = new ECPoint5w(x, y, z, z2, z3);
+            var p2 = new ECPoint5w(x, y, z, z2, z3);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void ECPoint5w_List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var list = new List<ECPoint5w>();
+            var p1 = new ECPoint5w(x, y, z, z2, z3);
+            var p2 = new ECPoint5w(x, y, z, z2, z3);
+
+            list.Add(p1);
+            Assert.Contains(p2, list);
+        }
+
+        [Fact]
+        public void ECPoint5w_List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint5w>();
+            var inf1 = ECPoint5w.POINT_INFINITY;
+            var inf2 = ECPoint5w.POINT_INFINITY;
+
+            list.Add(inf1);
+            Assert.Contains(inf2, list);
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint5w_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ECPoint5w_ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var original = new ECPoint5w(x, y, z, z2, z3);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void ECPoint5w_Points_CanRepresentSecp256k1GeneratorInJacobianChudnovsky()
+        {
+            /* secp256k1 generator point in affine */
+            var gx = BigInteger.Parse("55066263022277343669578718895168534326250603453777594175500187360389116729240");
+            var gy = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger z = 1;
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var generator = new ECPoint5w(gx, gy, z, z2, z3);
+            Assert.False(generator.IsInfinity);
+            Assert.Equal(gx, generator.X);
+
+            Assert.Equal(gy, generator.Y);
+            Assert.Equal(1, generator.Z);
+
+            Assert.Equal(1, generator.Z2);
+            Assert.Equal(1, generator.Z3);
+        }
+
+        [Fact]
+        public void ECPoint5w_Points_WithProjectiveZ_CorrectlyStored()
+        {
+            var x = BigInteger.Parse("123456789012345678901234567890");
+            var y = BigInteger.Parse("987654321098765432109876543210");
+
+            BigInteger z = 5;
+            BigInteger z2 = 25;
+            BigInteger z3 = 125;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(z2, point.Z2);
+
+            Assert.Equal(z3, point.Z3);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_Points_IdentityElement_UsedInECCContext()
+        {
+            var infinity = ECPoint5w.POINT_INFINITY;
+            BigInteger x = 5;
+
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            BigInteger z2 = 1;
+            BigInteger z3 = 1;
+
+            var point = new ECPoint5w(x, y, z, z2, z3);
+            Assert.False(point.Equals(infinity));
+
+            Assert.True(infinity.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint5w_Points_InfinityRequiresZeroZPowers()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            BigInteger z2 = 0;
+            BigInteger z3 = 0;
+
+            var infinity = new ECPoint5w(x, y, z, z2, z3);
+            Assert.True(infinity.IsInfinity);
+            Assert.Equal(0, infinity.Z);
+
+            Assert.Equal(0, infinity.Z2);
+            Assert.Equal(0, infinity.Z3);
+        }
+
+        #endregion
+
+        #region Stress Tests
+
+        [Fact]
+        public void ECPoint5w_ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 10) + 1;
+                BigInteger z2 = z * z;
+                BigInteger z3 = z * z * z;
+
+                var point = new ECPoint5w(x, y, z, z2, z3);
+                Assert.Equal(x, point.X);
+
+                Assert.Equal(y, point.Y);
+                Assert.Equal(z, point.Z);
+
+                Assert.Equal(z2, point.Z2);
+                Assert.Equal(z3, point.Z3);
+            }
+        }
+
+        [Fact]
+        public void ECPoint5w_HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 5) + 1;
+                BigInteger z2 = z * z;
+                BigInteger z3 = z * z * z;
+
+                var point = new ECPoint5w(x, y, z, z2, z3);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 95);
+        }
+
+        [Fact]
+        public void ECPoint5w_InfinityCreation_WithNonZeroZ2_AlwaysThrows()
+        {
+            var nonZeroZ2Values = new[] { 1, 5, -1, 100 };
+
+            foreach (var z2 in nonZeroZ2Values)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    new ECPoint5w(1, 1, 0, z2, 0));
+            }
+        }
+
+        [Fact]
+        public void ECPoint5w_InfinityCreation_WithNonZeroZ3_AlwaysThrows()
+        {
+            var nonZeroZ3Values = new[] { 1, 5, -1, 100 };
+
+            foreach (var z3 in nonZeroZ3Values)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    new ECPoint5w(1, 1, 0, 0, z3));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Tests/Points/ExtProjectivePointTests.cs
+++ b/UnitTests/Tests/Points/ExtProjectivePointTests.cs
@@ -1,0 +1,1252 @@
+﻿using System;
+using Eduard.Security.Primitives;
+using System.Collections.Generic;
+
+namespace Eduard.Tests.Points
+{
+    public class ExtProjectivePointTests
+    {
+        #region Constructor Tests
+
+        [Fact]
+        public void ECPoint4_Constructor_WithValidCoordinates_CreatesExtendedProjectivePoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNonUnitZ_CreatesValidPoint()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+
+            BigInteger t = 36;
+            BigInteger z = 2;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithZZeroAndTZero_CreatesInfinityPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithZZeroAndNonZeroT_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+
+            BigInteger t = 5;
+            BigInteger z = 0;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ECPoint4(x, y, t, z));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            BigInteger t = 0;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            BigInteger t = 1;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4(null, y, t, z));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4(x, null, t, z));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNullT_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4(x, y, null, z));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithNullZ_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger t = 50;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4(x, y, t, null));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithAllNullCoordinates_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4(null, null, null, null));
+        }
+
+        [Fact]
+        public void ECPoint4_Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger t = BigInteger.Parse("12345678901234567890");
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void ECPoint4_PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_PointInfinity_HasZEqualToZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_PointInfinity_HasTEqualToZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.T);
+        }
+
+        [Fact]
+        public void ECPoint4_PointInfinity_NormalizedCoordinates_ReturnsZeroOneZeroZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.X);
+            Assert.Equal(1, infinity.Y);
+
+            Assert.Equal(0, infinity.T);
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint4.POINT_INFINITY;
+            var infinity2 = ECPoint4.POINT_INFINITY;
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
+
+        [Fact]
+        public void ECPoint4_PointInfinity_AnyPointWithZZeroAndTZero_IsInfinity()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.True(point.IsInfinity);
+
+            Assert.Equal(0, point.Z);
+            Assert.Equal(0, point.T);
+        }
+
+        [Fact]
+        public void ECPoint4_DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint4);
+            Assert.True(defaultPoint.IsInfinity);
+
+            Assert.Equal(0, defaultPoint.X);
+            Assert.Equal(1, defaultPoint.Y);
+
+            Assert.Equal(0, defaultPoint.T);
+            Assert.Equal(0, defaultPoint.Z);
+        }
+
+        #endregion
+
+        #region Coordinate Accessor Tests
+
+        [Fact]
+        public void ECPoint4_GetX_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(x, point.X);
+        }
+
+        [Fact]
+        public void ECPoint4_GetX_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.X);
+        }
+
+        [Fact]
+        public void ECPoint4_GetX_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(0, point.X);
+        }
+
+        [Fact]
+        public void ECPoint4_GetX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger t = 838102050;
+            BigInteger z = 3;
+
+            var point = new ECPoint4(x, y, t, z);
+            var result1 = point.X;
+
+            var result2 = point.X;
+            var result3 = point.X;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4_GetY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(y, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint4_GetY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(1, infinity.Y);
+        }
+
+        [Fact]
+        public void ECPoint4_GetY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(1, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint4_GetY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger t = 838102050;
+            BigInteger z = 3;
+
+            var point = new ECPoint4(x, y, t, z);
+            var result1 = point.Y;
+
+            var result2 = point.Y;
+            var result3 = point.Y;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4_GetT_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(t, point.T);
+        }
+
+        [Fact]
+        public void ECPoint4_GetT_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.T);
+        }
+
+        [Fact]
+        public void ECPoint4_GetT_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(0, point.T);
+        }
+
+        [Fact]
+        public void ECPoint4_GetT_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger t = 838102050;
+            BigInteger z = 3;
+
+            var point = new ECPoint4(x, y, t, z);
+            var result1 = point.T;
+
+            var result2 = point.T;
+            var result3 = point.T;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4_GetZ_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 2;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_GetZ_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_GetZ_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_GetZ_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger t = 838102050;
+            BigInteger z = 7;
+
+            var point = new ECPoint4(x, y, t, z);
+            var result1 = point.Z;
+
+            var result2 = point.Z;
+            var result3 = point.Z;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4_CoordinateAccessors_WithLargeT_ReturnCorrectValues()
+        {
+            BigInteger x = 100;
+            BigInteger y = 200;
+
+            BigInteger t = BigInteger.Parse("12345678901234567890");
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(t, point.T);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Point Validity Tests
+
+        [Fact]
+        public void ECPoint4_IsInfinity_FinitePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint4.POINT_INFINITY.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_IsInfinity_NonZeroZ_ReturnsFalse()
+        {
+            var zValues = new[] { 1, 2, 3, 100 };
+
+            foreach (var zVal in zValues)
+            {
+                BigInteger x = 5;
+                BigInteger y = 10;
+
+                BigInteger t = 50 / zVal;
+                BigInteger z = zVal;
+
+                var point = new ECPoint4(x, y, t, z);
+                Assert.False(point.IsInfinity);
+            }
+        }
+
+        [Fact]
+        public void ECPoint4_IsInfinity_ZeroZAndZeroT_AlwaysReturnsTrue()
+        {
+            var coordinates = new[]
+            {
+                (0, 1), (1, 1), (-1, -1), 
+                (42, 100), (999, 888)
+            };
+
+            foreach (var (xVal, yVal) in coordinates)
+            {
+                BigInteger x = xVal;
+                BigInteger y = yVal;
+
+                BigInteger t = 0;
+                BigInteger z = 0;
+
+                var point = new ECPoint4(x, y, t, z);
+                Assert.True(point.IsInfinity);
+            }
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void ECPoint4_Equals_SameCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+
+            Assert.True(point1.Equals(point2));
+            Assert.True(point1 == point2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.True(point.Equals(point));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint4.POINT_INFINITY;
+            var inf2 = ECPoint4.POINT_INFINITY;
+
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10, t1 = 0, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, t2 = 0, z2 = 0;
+
+            var off1 = new ECPoint4(x1, y1, t1, z1);
+            var off2 = new ECPoint4(x2, y2, t2, z2);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_SameExtendedCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+
+            BigInteger t = 36;
+            BigInteger z = 2;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            BigInteger t = 0;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            BigInteger t = 1;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger t = BigInteger.Parse("12345678901234567890");
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x1, y, t, z);
+            var point2 = new ECPoint4(x2, y, t, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y1, t, z);
+            var point2 = new ECPoint4(x, y2, t, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_DifferentTCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t1 = 50, t2 = 100;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t1, z);
+            var point2 = new ECPoint4(x, y, t2, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_DifferentZCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z1 = 1, z2 = 2;
+
+            var point1 = new ECPoint4(x, y, t, z1);
+            var point2 = new ECPoint4(x, y, t, z2);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10, t1 = 50, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, t2 = 150, z2 = 2;
+            var point1 = new ECPoint4(x1, y1, t1, z1);
+
+            var point2 = new ECPoint4(x2, y2, t2, z2);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            var infinity = ECPoint4.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint4(x, y, 50, 1);
+            var offCurve = new ECPoint4(x, y, 0, 0);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void ECPoint4_Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void ECPoint4_EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var p1 = new ECPoint4(x, y, t, z);
+            var p2 = new ECPoint4(x, y, t, z);
+
+            var p3 = new ECPoint4(x, y, t, z);
+            Assert.True(p1 == p2);
+
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void ECPoint4_InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var p1 = new ECPoint4(x, y, t, z);
+            var p2 = new ECPoint4(x, y, t, z);
+            var p3 = new ECPoint4(x + 1, y, t, z);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
+        }
+
+        #endregion
+
+        #region GetHashCode Tests
+
+        [Fact]
+        public void ECPoint4_GetHashCode_SamePoints_HaveSameHashCode()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x, y, t, z);
+
+            Assert.Equal(point1.GetHashCode(), 
+                point2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10, t1 = 0, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, t2 = 0, z2 = 0;
+
+            var off1 = new ECPoint4(x1, y1, t1, z1);
+            var off2 = new ECPoint4(x2, y2, t2, z2);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), off2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t, z);
+            var point2 = new ECPoint4(x + 1, y, t, z);
+            int hash1 = point1.GetHashCode();
+
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_DifferentTValues_ProduceDifferentHashes()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t1 = 50, t2 = 100;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint4(x, y, t1, z);
+            var point2 = new ECPoint4(x, y, t2, z);
+            int hash1 = point1.GetHashCode();
+
+            int hash2 = point2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ECPoint4_GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1, -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    foreach (var zVal in new[] { 1, 2, 3 })
+                    {
+                        BigInteger x = xVal;
+                        BigInteger y = yVal;
+
+                        BigInteger t = xVal * yVal / zVal;
+                        BigInteger z = zVal;
+
+                        var point1 = new ECPoint4(x, y, t, z);
+                        var point2 = new ECPoint4(x, y, t, z);
+
+                        Assert.Equal(point1.GetHashCode(), 
+                            point2.GetHashCode());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Collection Integration Tests
+
+        [Fact]
+        public void ECPoint4_HashSet_HandlesExtendedProjectivePointsCorrectly()
+        {
+            BigInteger x1 = 5, y1 = 10, t1 = 50, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, t2 = 300, z2 = 1;
+
+            var set = new HashSet<ECPoint4>();
+            var p1 = new ECPoint4(x1, y1, t1, z1);
+
+            var p2 = new ECPoint4(x1, y1, t1, z1);
+            var p3 = new ECPoint4(x2, y2, t2, z2);
+
+            set.Add(p1);
+            Assert.Single(set);
+
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
+        }
+
+        [Fact]
+        public void ECPoint4_HashSet_DifferentTValues_TreatedAsDifferent()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t1 = 50, t2 = 100;
+            BigInteger z = 1;
+
+            var set = new HashSet<ECPoint4>();
+            var p1 = new ECPoint4(x, y, t1, z);
+            var p2 = new ECPoint4(x, y, t2, z);
+
+            set.Add(p1); set.Add(p2);
+            Assert.Equal(2, set.Count);
+        }
+
+        [Fact]
+        public void ECPoint4_HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint4>();
+            var inf1 = ECPoint4.POINT_INFINITY;
+
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var inf2 = new ECPoint4(x, y, t, z);
+            set.Add(inf1);
+
+            Assert.Single(set);
+            Assert.Contains(inf2, set);
+        }
+
+        [Fact]
+        public void ECPoint4_Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var dict = new Dictionary<ECPoint4, string>();
+            var p1 = new ECPoint4(x, y, t, z);
+            var p2 = new ECPoint4(x, y, t, z);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void ECPoint4_List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var list = new List<ECPoint4>();
+            var p1 = new ECPoint4(x, y, t, z);
+            var p2 = new ECPoint4(x, y, t, z);
+
+            list.Add(p1);
+            Assert.Contains(p2, list);
+        }
+
+        [Fact]
+        public void ECPoint4_List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint4>();
+            var inf1 = ECPoint4.POINT_INFINITY;
+            var inf2 = ECPoint4.POINT_INFINITY;
+
+            list.Add(inf1);
+            Assert.Contains(inf2, list);
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint4_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ECPoint4_ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var original = new ECPoint4(x, y, t, z);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void ECPoint4_Points_CanRepresentEd25519BasePointInExtended()
+        {
+            var x = BigInteger.Parse("15112221349535800782501122409520352403146587523749316481546487528623150257971");
+            var y = BigInteger.Parse("46316835694926478169428394003475163141307993866256225615783033603165251855960");
+
+            BigInteger t = BigInteger.Parse("46827403850823138040409258857748751836130598381944710651147842685073140789320");
+            BigInteger z = 1;
+
+            var basePoint = new ECPoint4(x, y, t, z);
+            Assert.False(basePoint.IsInfinity);
+
+            Assert.Equal(x, basePoint.X);
+            Assert.Equal(y, basePoint.Y);
+
+            Assert.Equal(t, basePoint.T);
+            Assert.Equal(1, basePoint.Z);
+        }
+
+        [Fact]
+        public void ECPoint4_Points_WithExtendedZ_CorrectlyStored()
+        {
+            var x = BigInteger.Parse("123456789012345678901234567890");
+            var y = BigInteger.Parse("987654321098765432109876543210");
+
+            BigInteger t = BigInteger.Parse("12193263113712995431619503321700856618036222682");
+            BigInteger z = 5;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(t, point.T);
+
+            Assert.Equal(z, point.Z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_Points_IdentityElement_UsedInECCContext()
+        {
+            var infinity = ECPoint4.POINT_INFINITY;
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger t = 50;
+            BigInteger z = 1;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.False(point.Equals(infinity));
+
+            Assert.True(infinity.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_Points_TRelationship_TEqualsXYDivZ()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+
+            BigInteger t = 36;
+            BigInteger z = 2;
+
+            var point = new ECPoint4(x, y, t, z);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(t, point.T);
+
+            Assert.Equal(z, point.Z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4_Points_InfinityRequiresZeroT()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+
+            BigInteger t = 0;
+            BigInteger z = 0;
+
+            var infinity = new ECPoint4(x, y, t, z);
+            Assert.True(infinity.IsInfinity);
+
+            Assert.Equal(0, infinity.Z);
+            Assert.Equal(0, infinity.T);
+        }
+
+        #endregion
+
+        #region Stress Tests
+
+        [Fact]
+        public void ECPoint4_ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 10) + 1;
+                BigInteger t = (x * y) / z;
+
+                var point = new ECPoint4(x, y, t, z);
+                Assert.Equal(x, point.X);
+                Assert.Equal(y, point.Y);
+
+                Assert.Equal(t, point.T);
+                Assert.Equal(z, point.Z);
+            }
+        }
+
+        [Fact]
+        public void ECPoint4_HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 5) + 1;
+                BigInteger t = (x * y) / z;
+
+                var point = new ECPoint4(x, y, t, z);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 95);
+        }
+
+        [Fact]
+        public void ECPoint4_InfinityCreation_WithNonZeroT_AlwaysThrows()
+        {
+            var nonZeroTValues = new[] { 1, 5, -1, 100, 
+                BigInteger.Parse("12345678901234567890") };
+
+            foreach (var t in nonZeroTValues)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    new ECPoint4(0, 1, t, 0));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Tests/Points/HomProjectivePointTests.cs
+++ b/UnitTests/Tests/Points/HomProjectivePointTests.cs
@@ -1,0 +1,1018 @@
+﻿using System;
+using Eduard.Security.Primitives;
+using System.Collections.Generic;
+
+namespace Eduard.Tests.Points
+{
+    public class HomProjectivePointTests
+    {
+        #region Constructor Tests
+
+        [Fact]
+        public void ECPoint3_Constructor_WithValidCoordinates_CreatesProjectivePoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithNonUnitZ_CreatesValidPoint()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+
+            BigInteger z = 2;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithZZero_CreatesInfinityPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            BigInteger z = 1;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            BigInteger z = 1;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3(null, y, z));
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3(x, null, z));
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithNullZ_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3(x, y, null));
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithAllNullCoordinates_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3(null, null, null));
+        }
+
+        [Fact]
+        public void ECPoint3_Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger z = 1;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.False(point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void ECPoint3_PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_PointInfinity_HasZEqualToZero()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_PointInfinity_NormalizedCoordinates_ReturnsZeroOneZero()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(0, infinity.X);
+
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint3.POINT_INFINITY;
+            var infinity2 = ECPoint3.POINT_INFINITY;
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
+
+        [Fact]
+        public void ECPoint3_PointInfinity_AnyPointWithZZero_IsInfinity()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            var point = new ECPoint3(x, y, z);
+
+            Assert.True(point.IsInfinity);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint3);
+            Assert.True(defaultPoint.IsInfinity);
+            Assert.Equal(0, defaultPoint.X);
+
+            Assert.Equal(1, defaultPoint.Y);
+            Assert.Equal(0, defaultPoint.Z);
+        }
+
+        #endregion
+
+        #region Coordinate Accessor Tests
+
+        [Fact]
+        public void ECPoint3_GetX_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(x, point.X);
+        }
+
+        [Fact]
+        public void ECPoint3_GetX_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(0, infinity.X);
+        }
+
+        [Fact]
+        public void ECPoint3_GetX_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(0, point.X);
+        }
+
+        [Fact]
+        public void ECPoint3_GetX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            var point = new ECPoint3(x, y, z);
+            var result1 = point.X;
+
+            var result2 = point.X;
+            var result3 = point.X;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3_GetY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(y, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint3_GetY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(1, infinity.Y);
+        }
+
+        [Fact]
+        public void ECPoint3_GetY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(1, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint3_GetY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            var point = new ECPoint3(x, y, z);
+            var result1 = point.Y;
+
+            var result2 = point.Y;
+            var result3 = point.Y;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3_GetZ_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_GetZ_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_GetZ_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_GetZ_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 7;
+
+            var point = new ECPoint3(x, y, z);
+            var result1 = point.Z;
+
+            var result2 = point.Z;
+            var result3 = point.Z;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3_CoordinateAccessors_WithLargeZ_ReturnCorrectValues()
+        {
+            BigInteger x = 100;
+            BigInteger y = 200;
+
+            BigInteger z = BigInteger.Parse("12345678901234567890");
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Point Validity Tests
+
+        [Fact]
+        public void ECPoint3_IsInfinity_FinitePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint3.POINT_INFINITY.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_IsInfinity_NonZeroZ_ReturnsFalse()
+        {
+            var zValues = new[] { 1, 2, 3, 100, -1, -5 };
+
+            foreach (var zVal in zValues)
+            {
+                BigInteger x = 5;
+                BigInteger y = 10;
+                BigInteger z = zVal;
+
+                var point = new ECPoint3(x, y, z);
+                Assert.False(point.IsInfinity);
+            }
+        }
+
+        [Fact]
+        public void ECPoint3_IsInfinity_ZeroZ_AlwaysReturnsTrue()
+        {
+            var coordinates = new[]
+            {
+                (0, 1), (1, 1), (-1, -1), 
+                (42, 100), (999, 888)
+            };
+
+            foreach (var (xVal, yVal) in coordinates)
+            {
+                BigInteger x = xVal;
+                BigInteger y = yVal;
+                BigInteger z = 0;
+
+                var point = new ECPoint3(x, y, z);
+                Assert.True(point.IsInfinity);
+            }
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void ECPoint3_Equals_SameCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+
+            Assert.True(point1.Equals(point2));
+            Assert.True(point1 == point2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.True(point.Equals(point));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint3.POINT_INFINITY;
+            var inf2 = ECPoint3.POINT_INFINITY;
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0;
+
+            var off1 = new ECPoint3(x1, y1, z1);
+            var off2 = new ECPoint3(x2, y2, z2);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_SameProjectiveCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x1, y, z);
+            var point2 = new ECPoint3(x2, y, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y1, z);
+            var point2 = new ECPoint3(x, y2, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_DifferentZCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z1 = 1, z2 = 2;
+
+            var point1 = new ECPoint3(x, y, z1);
+            var point2 = new ECPoint3(x, y, z2);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 2;
+            var point1 = new ECPoint3(x1, y1, z1);
+
+            var point2 = new ECPoint3(x2, y2, z2);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            var infinity = ECPoint3.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint3(x, y, 1);
+            var offCurve = new ECPoint3(x, y, 0);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void ECPoint3_Equals_SwappedCoordinates_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            var point1 = new ECPoint3(x, y, z);
+
+            var point2 = new ECPoint3(y, x, z);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3_EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var p1 = new ECPoint3(x, y, z);
+            var p2 = new ECPoint3(x, y, z);
+
+            var p3 = new ECPoint3(x, y, z);
+            Assert.True(p1 == p2);
+
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void ECPoint3_InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            var p1 = new ECPoint3(x, y, z);
+
+            var p2 = new ECPoint3(x, y, z);
+            var p3 = new ECPoint3(x + 1, y, z);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
+        }
+
+        #endregion
+
+        #region GetHashCode Tests
+
+        [Fact]
+        public void ECPoint3_GetHashCode_SamePoints_HaveSameHashCode()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3(x, y, z);
+            var point2 = new ECPoint3(x, y, z);
+
+            Assert.Equal(point1.GetHashCode(), 
+                point2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0;
+
+            var off1 = new ECPoint3(x1, y1, z1);
+            var off2 = new ECPoint3(x2, y2, z2);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), off2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            var point1 = new ECPoint3(x, y, z);
+
+            var point2 = new ECPoint3(x + 1, y, z);
+            int hash1 = point1.GetHashCode();
+
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_DifferentZValues_ProduceDifferentHashes()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            var point1 = new ECPoint3(x, y, z1);
+
+            var point2 = new ECPoint3(x, y, z2);
+            int hash1 = point1.GetHashCode();
+
+            int hash2 = point2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ECPoint3_GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1, -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    foreach (var zVal in new[] { 1, 2, 3 })
+                    {
+                        BigInteger x = xVal;
+                        BigInteger y = yVal;
+                        BigInteger z = zVal;
+
+                        var point1 = new ECPoint3(x, y, z);
+                        var point2 = new ECPoint3(x, y, z);
+
+                        Assert.Equal(point1.GetHashCode(), 
+                            point2.GetHashCode());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Collection Integration Tests
+
+        [Fact]
+        public void ECPoint3_HashSet_HandlesProjectivePointsCorrectly()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 1;
+
+            var set = new HashSet<ECPoint3>();
+            var p1 = new ECPoint3(x1, y1, z1);
+
+            var p2 = new ECPoint3(x1, y1, z1);
+            var p3 = new ECPoint3(x2, y2, z2);
+
+            set.Add(p1);
+            Assert.Single(set);
+
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
+        }
+
+        [Fact]
+        public void ECPoint3_HashSet_DifferentZValues_TreatedAsDifferent()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            var set = new HashSet<ECPoint3>();
+
+            var p1 = new ECPoint3(x, y, z1);
+            var p2 = new ECPoint3(x, y, z2);
+
+            set.Add(p1);
+            set.Add(p2);
+            Assert.Equal(2, set.Count);
+        }
+
+        [Fact]
+        public void ECPoint3_HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint3>();
+            var inf1 = ECPoint3.POINT_INFINITY;
+            BigInteger x = 42;
+
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var inf2 = new ECPoint3(x, y, z);
+            set.Add(inf1);
+
+            Assert.Single(set);
+            Assert.Contains(inf2, set);
+        }
+
+        [Fact]
+        public void ECPoint3_Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var dict = new Dictionary<ECPoint3, string>();
+            var p1 = new ECPoint3(x, y, z);
+            var p2 = new ECPoint3(x, y, z);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void ECPoint3_List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var list = new List<ECPoint3>();
+            var p1 = new ECPoint3(x, y, z);
+            var p2 = new ECPoint3(x, y, z);
+
+            list.Add(p1);
+            Assert.Contains(p2, list);
+        }
+
+        [Fact]
+        public void ECPoint3_List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint3>();
+            var inf1 = ECPoint3.POINT_INFINITY;
+            var inf2 = ECPoint3.POINT_INFINITY;
+
+            list.Add(inf1);
+            Assert.Contains(inf2, list);
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint3_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ECPoint3_ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var original = new ECPoint3(x, y, z);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void ECPoint3_Points_CanRepresentCurve25519BasePointInProjective()
+        {
+            var x = BigInteger.Parse("9");
+            var y = BigInteger.Parse("14781619447589544791020593568409986887264606134616475288964881837755586237401");
+            BigInteger z = 1;
+
+            var basePoint = new ECPoint3(x, y, z);
+            Assert.False(basePoint.IsInfinity);
+            Assert.Equal(x, basePoint.X);
+
+            Assert.Equal(y, basePoint.Y);
+            Assert.Equal(1, basePoint.Z);
+        }
+
+        [Fact]
+        public void ECPoint3_Points_WithProjectiveZ_CorrectlyStored()
+        {
+            var x = BigInteger.Parse("123456789012345678901234567890");
+            var y = BigInteger.Parse("987654321098765432109876543210");
+            BigInteger z = 5;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_Points_IdentityElement_UsedInECCContext()
+        {
+            var infinity = ECPoint3.POINT_INFINITY;
+            BigInteger x = 5;
+
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.False(point.Equals(infinity));
+
+            Assert.True(infinity.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3_Points_AffineMapping_XEqualsXDivZ()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            var point = new ECPoint3(x, y, z);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(z, point.Z);
+            Assert.False(point.IsInfinity);
+        }
+
+        #endregion
+
+        #region Stress Tests
+
+        [Fact]
+        public void ECPoint3_ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+                BigInteger z = (i % 10) + 1;
+
+                var point = new ECPoint3(x, y, z);
+                Assert.Equal(x, point.X);
+
+                Assert.Equal(y, point.Y);
+                Assert.Equal(z, point.Z);
+            }
+        }
+
+        [Fact]
+        public void ECPoint3_HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+                BigInteger z = (i % 5) + 1;
+
+                var point = new ECPoint3(x, y, z);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 20);
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Tests/Points/JacobianPointTests.cs
+++ b/UnitTests/Tests/Points/JacobianPointTests.cs
@@ -1,0 +1,994 @@
+﻿using System;
+using Eduard.Security.Primitives;
+using System.Collections.Generic;
+using Eduard;
+
+namespace Eduard.Tests.Points
+{
+    public class JacobianPointTests
+    {
+        #region Constructor Tests
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithValidCoordinates_CreatesJacobianPoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithNonUnitZ_CreatesValidPoint()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithZZero_CreatesInfinityPoint()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3w(null, y, z));
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3w(x, null, z));
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithNullZ_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3w(x, y, null));
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithAllNullCoordinates_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint3w(null, null, null));
+        }
+
+        [Fact]
+        public void ECPoint3w_Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(!point.IsInfinity);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void ECPoint3w_PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_PointInfinity_HasZEqualToZero()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_PointInfinity_NormalizedCoordinates_ReturnsOneOneZero()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+            Assert.Equal(1, infinity.Y);
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint3w.POINT_INFINITY;
+            var infinity2 = ECPoint3w.POINT_INFINITY;
+
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
+
+        [Fact]
+        public void ECPoint3w_PointInfinity_AnyPointWithZZero_IsInfinity()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(point.IsInfinity);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint3w);
+            Assert.True(defaultPoint.IsInfinity);
+            Assert.Equal(1, defaultPoint.X);
+
+            Assert.Equal(1, defaultPoint.Y);
+            Assert.Equal(0, defaultPoint.Z);
+        }
+
+        #endregion
+
+        #region Coordinate Accessor Tests
+
+        [Fact]
+        public void ECPoint3w_GetX_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(x, point.X);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetX_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetX_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(1, point.X);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            var point = new ECPoint3w(x, y, z);
+            var result1 = point.X;
+
+            var result2 = point.X;
+            var result3 = point.X;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(y, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(1, infinity.Y);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(1, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 3;
+
+            var point = new ECPoint3w(x, y, z);
+            var result1 = point.Y;
+
+            var result2 = point.Y;
+            var result3 = point.Y;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetZ_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 2;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetZ_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetZ_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetZ_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+            BigInteger z = 7;
+
+            var point = new ECPoint3w(x, y, z);
+            var result1 = point.Z;
+
+            var result2 = point.Z;
+            var result3 = point.Z;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint3w_CoordinateAccessors_WithLargeZ_ReturnCorrectValues()
+        {
+            BigInteger x = 100;
+            BigInteger y = 200;
+
+            BigInteger z = BigInteger.Parse("12345678901234567890");
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+        }
+
+        #endregion
+
+        #region Point Validity Tests
+
+        [Fact]
+        public void ECPoint3w_IsInfinity_FinitePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+            BigInteger z = 0;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint3w.POINT_INFINITY.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_IsInfinity_NonZeroZ_ReturnsFalse()
+        {
+            var zValues = new[] { 1, 2, 3,
+                100, -1, -5 };
+
+            foreach (var zVal in zValues)
+            {
+                BigInteger x = 5;
+                BigInteger y = 10;
+                BigInteger z = zVal;
+
+                var point = new ECPoint3w(x, y, z);
+                Assert.False(point.IsInfinity);
+            }
+        }
+
+        [Fact]
+        public void ECPoint3w_IsInfinity_ZeroZ_AlwaysReturnsTrue()
+        {
+            var coordinates = new[]
+            {
+                (1, 1), (0, 0), (-1, -1),
+                (42, 100), (999, 888)
+            };
+
+            foreach (var (xVal, yVal) in coordinates)
+            {
+                BigInteger x = xVal;
+                BigInteger y = yVal;
+                BigInteger z = 0;
+
+                var point = new ECPoint3w(x, y, z);
+                Assert.True(point.IsInfinity);
+            }
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void ECPoint3w_Equals_SameCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+
+            Assert.True(point1.Equals(point2));
+            Assert.True(point1 == point2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(point.Equals(point));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint3w.POINT_INFINITY;
+            var inf2 = ECPoint3w.POINT_INFINITY;
+
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0;
+
+            var off1 = new ECPoint3w(x1, y1, z1);
+            var off2 = new ECPoint3w(x2, y2, z2);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_SameProjectiveCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x1, y, z);
+            var point2 = new ECPoint3w(x2, y, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y1, z);
+            var point2 = new ECPoint3w(x, y2, z);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_DifferentZCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            var point1 = new ECPoint3w(x, y, z1);
+            var point2 = new ECPoint3w(x, y, z2);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 2;
+
+            var point1 = new ECPoint3w(x1, y1, z1);
+            var point2 = new ECPoint3w(x2, y2, z2);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            var infinity = ECPoint3w.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint3w(x, y, 1);
+            var offCurve = new ECPoint3w(x, y, 0);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void ECPoint3w_Equals_SwappedCoordinates_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(y, x, z);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint3w_EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var p1 = new ECPoint3w(x, y, z);
+            var p2 = new ECPoint3w(x, y, z);
+            var p3 = new ECPoint3w(x, y, z);
+
+            Assert.True(p1 == p2);
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void ECPoint3w_InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var p1 = new ECPoint3w(x, y, z);
+            var p2 = new ECPoint3w(x, y, z);
+            var p3 = new ECPoint3w(x + 1, y, z);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
+        }
+
+        #endregion
+
+        #region GetHashCode Tests
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_SamePoints_HaveSameHashCode()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x, y, z);
+
+            Assert.Equal(point1.GetHashCode(),
+                point2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0;
+
+            var off1 = new ECPoint3w(x1, y1, z1);
+            var off2 = new ECPoint3w(x2, y2, z2);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), off2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point1 = new ECPoint3w(x, y, z);
+            var point2 = new ECPoint3w(x + 1, y, z);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_DifferentZValues_ProduceDifferentHashes()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z1 = 1, z2 = 2;
+
+            var point1 = new ECPoint3w(x, y, z1);
+            var point2 = new ECPoint3w(x, y, z2);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ECPoint3w_GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1,
+                -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    foreach (var zVal in new[] { 1, 2, 3 })
+                    {
+                        BigInteger x = xVal;
+                        BigInteger y = yVal;
+                        BigInteger z = zVal;
+
+                        var point1 = new ECPoint3w(x, y, z);
+                        var point2 = new ECPoint3w(x, y, z);
+
+                        Assert.Equal(point1.GetHashCode(),
+                            point2.GetHashCode());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Collection Integration Tests
+
+        [Fact]
+        public void ECPoint3w_HashSet_HandlesJacobianPointsCorrectly()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1;
+            BigInteger x2 = 15, y2 = 20, z2 = 1;
+
+            var set = new HashSet<ECPoint3w>();
+            var p1 = new ECPoint3w(x1, y1, z1);
+
+            var p2 = new ECPoint3w(x1, y1, z1);
+            var p3 = new ECPoint3w(x2, y2, z2);
+
+            set.Add(p1);
+            Assert.Single(set);
+
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
+        }
+
+        [Fact]
+        public void ECPoint3w_HashSet_DifferentZValues_TreatedAsDifferent()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            var set = new HashSet<ECPoint3w>();
+
+            var p1 = new ECPoint3w(x, y, z1);
+            var p2 = new ECPoint3w(x, y, z2);
+
+            set.Add(p1); set.Add(p2);
+            Assert.Equal(2, set.Count);
+        }
+
+        [Fact]
+        public void ECPoint3w_HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint3w>();
+            var inf1 = ECPoint3w.POINT_INFINITY;
+            BigInteger x = 42;
+            BigInteger y = 100;
+            BigInteger z = 0;
+
+            var inf2 = new ECPoint3w(x, y, z);
+            set.Add(inf1);
+
+            Assert.Single(set);
+            Assert.Contains(inf2, set);
+        }
+
+        [Fact]
+        public void ECPoint3w_Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var dict = new Dictionary<ECPoint3w, string>();
+            var p1 = new ECPoint3w(x, y, z);
+            var p2 = new ECPoint3w(x, y, z);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void ECPoint3w_List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var list = new List<ECPoint3w>();
+            var p1 = new ECPoint3w(x, y, z);
+            var p2 = new ECPoint3w(x, y, z);
+
+            list.Add(p1);
+
+            Assert.Contains(p2, list);
+        }
+
+        [Fact]
+        public void ECPoint3w_List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint3w>();
+            var inf1 = ECPoint3w.POINT_INFINITY;
+            var inf2 = ECPoint3w.POINT_INFINITY;
+
+            list.Add(inf1);
+            Assert.Contains(inf2, list);
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint3w_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ECPoint3w_ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            var original = new ECPoint3w(x, y, z);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void ECPoint3w_Points_CanRepresentSecp256k1GeneratorInJacobian()
+        {
+            /* secp256k1 generator point in affine */
+            var gx = BigInteger.Parse("55066263022277343669578718895168534326250603453777594175500187360389116729240");
+            var gy = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            var generator = new ECPoint3w(gx, gy, z);
+            Assert.False(generator.IsInfinity);
+            Assert.Equal(gx, generator.X);
+
+            Assert.Equal(gy, generator.Y);
+            Assert.Equal(1, generator.Z);
+        }
+
+        [Fact]
+        public void ECPoint3w_Points_WithProjectiveZ_CorrectlyStored()
+        {
+            var x = BigInteger.Parse("123456789012345678901234567890");
+            var y = BigInteger.Parse("987654321098765432109876543210");
+            BigInteger z = 5;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.True(!point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint3w_Points_IdentityElement_UsedInECCContext()
+        {
+            var infinity = ECPoint3w.POINT_INFINITY;
+            BigInteger x = 5, y = 10, z = 1;
+
+            var point = new ECPoint3w(x, y, z);
+            Assert.False(point.Equals(infinity));
+
+            Assert.True(infinity.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        #endregion
+
+        #region Stress Tests
+
+        [Fact]
+        public void ECPoint3w_ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 10) + 1;
+                var point = new ECPoint3w(x, y, z);
+                Assert.Equal(x, point.X);
+
+                Assert.Equal(y, point.Y);
+                Assert.Equal(z, point.Z);
+            }
+        }
+
+        [Fact]
+        public void ECPoint3w_HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+                BigInteger z = (i % 5) + 1;
+
+                var point = new ECPoint3w(x, y, z);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 20);
+        }
+
+        #endregion
+    }
+}

--- a/UnitTests/Tests/Points/ModJacobianPointTests.cs
+++ b/UnitTests/Tests/Points/ModJacobianPointTests.cs
@@ -1,0 +1,1281 @@
+﻿using System;
+using Eduard.Security.Primitives;
+using System.Collections.Generic;
+
+namespace Eduard.Tests.Points
+{
+    public class ModJacobianPointTests
+    {
+        #region Constructor Tests
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithValidCoordinates_CreatesModifiedJacobianPoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(!point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNonUnitZ_CreatesValidPoint()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+            BigInteger z = 2;
+            BigInteger az4 = 32;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(!point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+            
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithZZeroAndAZ4Zero_CreatesInfinityPoint()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithZZeroAndNonZeroAZ4_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+
+            BigInteger z = 0;
+            BigInteger az4 = 5;
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new ECPoint4w(x, y, z, az4));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithZeroCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            BigInteger z = 1;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(!point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNegativeCoordinates_CreatesValidPoint()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            BigInteger z = 1;
+            BigInteger az4 = -2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(!point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNullX_ThrowsArgumentNullException()
+        {
+            BigInteger y = 10;
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4w(null, y, z, az4));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNullY_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4w(x, null, z, az4));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNullZ_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger az4 = 2;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4w(x, y, null, az4));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNullAZ4_ThrowsArgumentNullException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4w(x, y, z, null));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithAllNullCoordinates_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new ECPoint4w(null, null, null, null));
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithLargeCoordinates_CreatesValidPoint()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            BigInteger az4 = BigInteger.Parse("12345678901234567890");
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(!point.IsInfinity);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Constructor_WithNegativeZ_ThrowsInvalidOperationException()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = -1;
+            BigInteger az4 = 2;
+
+            var exception = Record.Exception(() =>
+                new ECPoint4w(x, y, z, az4));
+
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Identity Element Tests
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_ReturnsIdentityElement()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.True(infinity.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_HasZEqualToZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_HasAZ4EqualToZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(0, infinity.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_NormalizedCoordinates_ReturnsOneOneZeroZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+            Assert.Equal(1, infinity.Y);
+
+            Assert.Equal(0, infinity.Z);
+            Assert.Equal(0, infinity.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_MultipleCalls_ReturnEqualInstances()
+        {
+            var infinity1 = ECPoint4w.POINT_INFINITY;
+            var infinity2 = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(infinity1, infinity2);
+            Assert.True(infinity1 == infinity2);
+        }
+
+        [Fact]
+        public void ECPoint4w_PointInfinity_AnyPointWithZZeroAndAZ4Zero_IsInfinity()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.IsInfinity);
+
+            Assert.Equal(0, point.Z);
+            Assert.Equal(0, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_DefaultStructValue_BehavesAsIdentityElement()
+        {
+            var defaultPoint = default(ECPoint4w);
+            Assert.True(defaultPoint.IsInfinity);
+
+            Assert.Equal(1, defaultPoint.X);
+            Assert.Equal(1, defaultPoint.Y);
+
+            Assert.Equal(0, defaultPoint.Z);
+            Assert.Equal(0, defaultPoint.aZ4);
+        }
+
+        #endregion
+
+        #region Coordinate Accessor Tests
+
+        [Fact]
+        public void ECPoint4w_GetX_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(x, point.X);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetX_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(1, infinity.X);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetX_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(1, point.X);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetX_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger z = 3;
+            BigInteger az4 = 162;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            var result1 = point.X;
+
+            var result2 = point.X;
+            var result3 = point.X;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetY_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(y, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetY_IdentityElement_ReturnsOne()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(1, infinity.Y);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetY_OffCurvePoint_ReturnsOne()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(1, point.Y);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetY_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger z = 3;
+            BigInteger az4 = 162;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            var result1 = point.Y;
+
+            var result2 = point.Y;
+            var result3 = point.Y;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetZ_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 2;
+            BigInteger az4 = 32;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(z, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetZ_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(0, infinity.Z);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetZ_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(0, point.Z);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetZ_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger z = 7;
+            BigInteger az4 = 2401;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            var result1 = point.Z;
+
+            var result2 = point.Z;
+            var result3 = point.Z;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetAZ4_FinitePoint_ReturnsStoredValue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 2;
+            BigInteger az4 = 32;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetAZ4_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(0, infinity.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetAZ4_OffCurvePoint_ReturnsZero()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(0, point.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetAZ4_MultipleCalls_ReturnsConsistentResult()
+        {
+            BigInteger x = 12345;
+            BigInteger y = 67890;
+
+            BigInteger z = 3;
+            BigInteger az4 = 162;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            var result1 = point.aZ4;
+
+            var result2 = point.aZ4;
+            var result3 = point.aZ4;
+
+            Assert.Equal(result1, result2);
+            Assert.Equal(result2, result3);
+        }
+
+        [Fact]
+        public void ECPoint4w_CoordinateAccessors_WithLargeAZ4_ReturnCorrectValues()
+        {
+            BigInteger x = 100;
+            BigInteger y = 200;
+            BigInteger z = 1;
+
+            BigInteger az4 = BigInteger.Parse("12345678901234567890");
+            var point = new ECPoint4w(x, y, z, az4);
+
+            Assert.Equal(x, point.X);
+            Assert.Equal(y, point.Y);
+
+            Assert.Equal(z, point.Z);
+            Assert.Equal(az4, point.aZ4);
+        }
+
+        #endregion
+
+        #region Point Validity Tests
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_FinitePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_IdentityElement_ReturnsTrue()
+        {
+            BigInteger x = 1;
+            BigInteger y = 1;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_PointAtInfinityConstant_ReturnsTrue()
+        {
+            Assert.True(ECPoint4w.POINT_INFINITY.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_MatchesIsOnCurveNegation_ForFinitePoint()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_MatchesIsOnCurveNegation_ForIdentityElement()
+        {
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_NonZeroZ_ReturnsFalse()
+        {
+            var zValues = new[] { 1, 2, 3, 100 };
+
+            foreach (var zVal in zValues)
+            {
+                BigInteger x = 5;
+                BigInteger y = 10;
+                BigInteger z = zVal;
+
+                BigInteger az4 = zVal * zVal * zVal * zVal;
+                var point = new ECPoint4w(x, y, z, az4);
+                Assert.False(point.IsInfinity);
+            }
+        }
+
+        [Fact]
+        public void ECPoint4w_IsInfinity_ZeroZAndZeroAZ4_AlwaysReturnsTrue()
+        {
+            var coordinates = new[]
+            {
+                (1, 1), (0, 0), (-1, -1), 
+                (42, 100), (999, 888)
+            };
+
+            foreach (var (xVal, yVal) in coordinates)
+            {
+                BigInteger x = xVal;
+                BigInteger y = yVal;
+
+                BigInteger z = 0;
+                BigInteger az4 = 0;
+
+                var point = new ECPoint4w(x, y, z, az4);
+                Assert.True(point.IsInfinity);
+            }
+        }
+
+        #endregion
+
+        #region Equality Tests
+
+        [Fact]
+        public void ECPoint4w_Equals_SameCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x, y, z, az4);
+
+            Assert.True(point1.Equals(point2));
+            Assert.True(point1 == point2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_SameInstance_ReturnsTrue()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.Equals(point));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_TwoIdentityElements_ReturnsTrue()
+        {
+            var inf1 = ECPoint4w.POINT_INFINITY;
+            var inf2 = ECPoint4w.POINT_INFINITY;
+            Assert.True(inf1.Equals(inf2));
+            Assert.True(inf1 == inf2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_TwoOffCurvePoints_ReturnsTrue()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0, az41 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0, az42 = 0;
+
+            var off1 = new ECPoint4w(x1, y1, z1, az41);
+            var off2 = new ECPoint4w(x2, y2, z2, az42);
+
+            Assert.True(off1.Equals(off2));
+            Assert.True(off1 == off2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_SameProjectiveCoordinates_ReturnsTrue()
+        {
+            BigInteger x = 6;
+            BigInteger y = 12;
+
+            BigInteger z = 2;
+            BigInteger az4 = 32;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x, y, z, az4);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_ZeroCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = 0;
+            BigInteger y = 0;
+
+            BigInteger z = 1;
+            BigInteger az4 = 0;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x, y, z, az4);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_NegativeCoordinatePoints_ReturnsTrue()
+        {
+            BigInteger x = -1;
+            BigInteger y = -1;
+
+            BigInteger z = 1;
+            BigInteger az4 = -2;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x, y, z, az4);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_LargeCoordinatePoints_ReturnsTrue()
+        {
+            var x = BigInteger.Parse("115792089237316195423570985008687907853269984665640564039457584007908834671663");
+            var y = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+            BigInteger z = 1;
+
+            BigInteger az4 = BigInteger.Parse("12345678901234567890");
+            var point1 = new ECPoint4w(x, y, z, az4);
+
+            var point2 = new ECPoint4w(x, y, z, az4);
+            Assert.True(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_DifferentXCoordinate_ReturnsFalse()
+        {
+            BigInteger x1 = 5, x2 = 15;
+            BigInteger y = 10, z = 1;
+            BigInteger az4 = 2;
+
+            var point1 = new ECPoint4w(x1, y, z, az4);
+            var point2 = new ECPoint4w(x2, y, z, az4);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_DifferentYCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y1 = 10, y2 = 20;
+            BigInteger z = 1, az4 = 2;
+
+            var point1 = new ECPoint4w(x, y1, z, az4);
+            var point2 = new ECPoint4w(x, y2, z, az4);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_DifferentZCoordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z1 = 1, z2 = 2;
+            BigInteger az4 = 2;
+
+            var point1 = new ECPoint4w(x, y, z1, az4);
+            var point2 = new ECPoint4w(x, y, z2, az4);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_DifferentAZ4Coordinate_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az41 = 2, az42 = 3;
+
+            var point1 = new ECPoint4w(x, y, z, az41);
+            var point2 = new ECPoint4w(x, y, z, az42);
+
+            Assert.False(point1.Equals(point2));
+            Assert.True(point1 != point2);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_CompletelyDifferentCoordinates_ReturnsFalse()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1, az41 = 2;
+            BigInteger x2 = 15, y2 = 20, z2 = 2, az42 = 32;
+
+            var point1 = new ECPoint4w(x1, y1, z1, az41);
+            var point2 = new ECPoint4w(x2, y2, z2, az42);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_FinitePointVsIdentityElement_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            var infinity = ECPoint4w.POINT_INFINITY;
+
+            Assert.False(point.Equals(infinity));
+            Assert.True(point != infinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_FinitePointVsOffCurvePoint_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            var onCurve = new ECPoint4w(x, y, 1, 2);
+            var offCurve = new ECPoint4w(x, y, 0, 0);
+
+            Assert.False(onCurve.Equals(offCurve));
+            Assert.True(onCurve != offCurve);
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_NullObject_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.False(point.Equals(null));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_DifferentType_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.False(point.Equals("not a point"));
+
+            Assert.False(point.Equals(42));
+            Assert.False(point.Equals(new object()));
+        }
+
+        [Fact]
+        public void ECPoint4w_Equals_SameXYZ_DifferentAZ4_ReturnsFalse()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az41 = 2, az42 = 4;
+
+            var point1 = new ECPoint4w(x, y, z, az41);
+            var point2 = new ECPoint4w(x, y, z, az42);
+            Assert.False(point1.Equals(point2));
+        }
+
+        [Fact]
+        public void ECPoint4w_EqualityOperator_Transitivity()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var p1 = new ECPoint4w(x, y, z, az4);
+            var p2 = new ECPoint4w(x, y, z, az4);
+            var p3 = new ECPoint4w(x, y, z, az4);
+
+            Assert.True(p1 == p2);
+            Assert.True(p2 == p3);
+            Assert.True(p1 == p3);
+        }
+
+        [Fact]
+        public void ECPoint4w_InequalityOperator_OppositeOfEqualityOperator()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var p1 = new ECPoint4w(x, y, z, az4);
+            var p2 = new ECPoint4w(x, y, z, az4);
+            var p3 = new ECPoint4w(x + 1, y, z, az4);
+
+            Assert.True((p1 == p2) == !(p1 != p2));
+            Assert.True((p1 == p3) == !(p1 != p3));
+        }
+
+        #endregion
+
+        #region GetHashCode Tests
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_SamePoints_HaveSameHashCode()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x, y, z, az4);
+
+            Assert.Equal(point1.GetHashCode(), 
+                point2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_IdentityElement_ReturnsZero()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            Assert.Equal(0, infinity.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_OffCurvePoints_ReturnZero()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 0, az41 = 0;
+            BigInteger x2 = 42, y2 = 100, z2 = 0, az42 = 0;
+
+            var off1 = new ECPoint4w(x1, y1, z1, az41);
+            var off2 = new ECPoint4w(x2, y2, z2, az42);
+
+            Assert.Equal(0, off1.GetHashCode());
+            Assert.Equal(off1.GetHashCode(), off2.GetHashCode());
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_ConsistentAcrossMultipleCalls()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            int hash1 = point.GetHashCode();
+
+            int hash2 = point.GetHashCode();
+            int hash3 = point.GetHashCode();
+
+            Assert.Equal(hash1, hash2);
+            Assert.Equal(hash2, hash3);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_DifferentPoints_MayDiffer()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point1 = new ECPoint4w(x, y, z, az4);
+            var point2 = new ECPoint4w(x + 1, y, z, az4);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.True(hash1 != 0 || hash2 != 0);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_DifferentAZ4Values_ProduceDifferentHashes()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az41 = 2, az42 = 3;
+
+            var point1 = new ECPoint4w(x, y, z, az41);
+            var point2 = new ECPoint4w(x, y, z, az42);
+
+            int hash1 = point1.GetHashCode();
+            int hash2 = point2.GetHashCode();
+            Assert.NotEqual(hash1, hash2);
+        }
+
+        [Fact]
+        public void ECPoint4w_GetHashCode_VariousCoordinateValues_Consistent()
+        {
+            var values = new[] { 0, 1, 
+                -1, 42, 256 };
+
+            foreach (var xVal in values)
+            {
+                foreach (var yVal in values)
+                {
+                    foreach (var zVal in new[] { 1, 2, 3 })
+                    {
+                        BigInteger x = xVal;
+                        BigInteger y = yVal;
+                        BigInteger z = zVal;
+                        BigInteger az4 = zVal * zVal;
+
+                        var point1 = new ECPoint4w(x, y, z, az4);
+                        var point2 = new ECPoint4w(x, y, z, az4);
+
+                        Assert.Equal(point1.GetHashCode(), point2.GetHashCode());
+                    }
+                }
+            }
+        }
+
+        #endregion
+
+        #region Collection Integration Tests
+
+        [Fact]
+        public void ECPoint4w_HashSet_HandlesModifiedJacobianPointsCorrectly()
+        {
+            BigInteger x1 = 5, y1 = 10, z1 = 1, az41 = 2;
+            BigInteger x2 = 15, y2 = 20, z2 = 1, az42 = 2;
+
+            var set = new HashSet<ECPoint4w>();
+            var p1 = new ECPoint4w(x1, y1, z1, az41);
+
+            var p2 = new ECPoint4w(x1, y1, z1, az41);
+            var p3 = new ECPoint4w(x2, y2, z2, az42);
+
+            set.Add(p1);
+            Assert.Single(set);
+
+            Assert.Contains(p2, set);
+            Assert.DoesNotContain(p3, set);
+        }
+
+        [Fact]
+        public void ECPoint4w_HashSet_DifferentAZ4Values_TreatedAsDifferent()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az41 = 2, az42 = 3;
+
+            var set = new HashSet<ECPoint4w>();
+            var p1 = new ECPoint4w(x, y, z, az41);
+            var p2 = new ECPoint4w(x, y, z, az42);
+
+            set.Add(p1);
+            set.Add(p2);
+            Assert.Equal(2, set.Count);
+        }
+
+        [Fact]
+        public void ECPoint4w_HashSet_IdentityElementsHandledCorrectly()
+        {
+            var set = new HashSet<ECPoint4w>();
+            var inf1 = ECPoint4w.POINT_INFINITY;
+
+            BigInteger x = 42;
+            BigInteger y = 100;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var inf2 = new ECPoint4w(x, y, z, az4);
+            set.Add(inf1);
+
+            Assert.Single(set);
+            Assert.Contains(inf2, set);
+        }
+
+        [Fact]
+        public void ECPoint4w_Dictionary_HandlesPointsAsKeys()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var dict = new Dictionary<ECPoint4w, string>();
+            var p1 = new ECPoint4w(x, y, z, az4);
+            var p2 = new ECPoint4w(x, y, z, az4);
+
+            dict[p1] = "original";
+            Assert.Equal("original", dict[p2]);
+        }
+
+        [Fact]
+        public void ECPoint4w_List_ContainsUsesEquality()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var list = new List<ECPoint4w>();
+            var p1 = new ECPoint4w(x, y, z, az4);
+            var p2 = new ECPoint4w(x, y, z, az4);
+
+            list.Add(p1);
+
+            Assert.Contains(p2, list);
+        }
+
+        [Fact]
+        public void ECPoint4w_List_IdentityElement_ContainsWorks()
+        {
+            var list = new List<ECPoint4w>();
+            var inf1 = ECPoint4w.POINT_INFINITY;
+            var inf2 = ECPoint4w.POINT_INFINITY;
+
+            list.Add(inf1);
+
+            Assert.Contains(inf2, list);
+        }
+
+        #endregion
+
+        #region Value Type Semantics Tests
+
+        [Fact]
+        public void ECPoint4w_IsValueType()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.True(point.GetType().IsValueType);
+        }
+
+        [Fact]
+        public void ECPoint4w_ValueSemantics_AssignmentCreatesCopy()
+        {
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var original = new ECPoint4w(x, y, z, az4);
+            var copy = original;
+
+            Assert.Equal(original, copy);
+            Assert.True(original == copy);
+        }
+
+        #endregion
+
+        #region Real-World ECC Tests
+
+        [Fact]
+        public void ECPoint4w_Points_CanRepresentSecp256k1GeneratorInModifiedJacobian()
+        {
+            /* secp256k1 generator point in affine */
+            var gx = BigInteger.Parse("55066263022277343669578718895168534326250603453777594175500187360389116729240");
+            var gy = BigInteger.Parse("32670510020758816978083085130507043184471273380659243275938904335757337482424");
+
+            BigInteger z = 1;
+            BigInteger az4 = 0;
+
+            var generator = new ECPoint4w(gx, gy, z, az4);
+            Assert.False(generator.IsInfinity);
+
+            Assert.Equal(gx, generator.X);
+            Assert.Equal(gy, generator.Y);
+
+            Assert.Equal(1, generator.Z);
+            Assert.Equal(0, generator.aZ4);
+        }
+
+        [Fact]
+        public void ECPoint4w_Points_WithProjectiveZ_CorrectlyStored()
+        {
+            var x = BigInteger.Parse("123456789012345678901234567890");
+            var y = BigInteger.Parse("987654321098765432109876543210");
+
+            BigInteger z = 5;
+            BigInteger az4 = 625;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.Equal(x, point.X);
+
+            Assert.Equal(y, point.Y);
+            Assert.Equal(z, point.Z);
+
+            Assert.Equal(az4, point.aZ4);
+            Assert.True(!point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_Points_IdentityElement_UsedInECCContext()
+        {
+            var infinity = ECPoint4w.POINT_INFINITY;
+            BigInteger x = 5;
+            BigInteger y = 10;
+
+            BigInteger z = 1;
+            BigInteger az4 = 2;
+
+            var point = new ECPoint4w(x, y, z, az4);
+            Assert.False(point.Equals(infinity));
+
+            Assert.True(infinity.IsInfinity);
+            Assert.False(point.IsInfinity);
+        }
+
+        [Fact]
+        public void ECPoint4w_Points_InfinityRequiresZeroAZ4()
+        {
+            /* verify the invariant: point at infinity must have aZ^4 = 0 */
+            BigInteger x = 1;
+            BigInteger y = 1;
+
+            BigInteger z = 0;
+            BigInteger az4 = 0;
+
+            var infinity = new ECPoint4w(x, y, z, az4);
+            Assert.True(infinity.IsInfinity);
+
+            Assert.Equal(0, infinity.Z);
+            Assert.Equal(0, infinity.aZ4);
+        }
+
+        #endregion
+
+        #region Stress Tests
+
+        [Fact]
+        public void ECPoint4w_ManyPointsCreation_NoExceptions()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 10) + 1;
+                BigInteger az4 = z * z * z * z;
+                var point = new ECPoint4w(x, y, z, az4);
+
+                Assert.Equal(x, point.X);
+                Assert.Equal(y, point.Y);
+                Assert.Equal(z, point.Z);
+                Assert.Equal(az4, point.aZ4);
+            }
+        }
+
+        [Fact]
+        public void ECPoint4w_HashCodeDistribution_MultiplePoints()
+        {
+            var hashCodes = new HashSet<int>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                BigInteger x = i;
+                BigInteger y = i * 2;
+
+                BigInteger z = (i % 5) + 1;
+                BigInteger az4 = z * z * z * z;
+
+                var point = new ECPoint4w(x, y, z, az4);
+                hashCodes.Add(point.GetHashCode());
+            }
+
+            Assert.True(hashCodes.Count >= 95);
+        }
+
+        [Fact]
+        public void ECPoint4w_InfinityCreation_WithNonZeroAZ4_AlwaysThrows()
+        {
+            var nonZeroAZ4Values = new[] { 1, 5, -1, 100, 
+                BigInteger.Parse("12345678901234567890") };
+
+            foreach (var az4 in nonZeroAZ4Values)
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    new ECPoint4w(1, 1, 0, az4));
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
### Description

This PR delivers a broad set of improvements across the elliptic curve and polynomial arithmetic layers, with a focus on performance, safety, and test coverage.

#### BarrettReducer & field arithmetic
- Tighten coefficient bounds in `FastPolyMod` by integrating `BarrettReducer.Reduce`/`SubMod` for compact intermediate values.
- Add batch modular inversion (`InvMod(BigInteger[])`) implementing Montgomery’s simultaneous inversion trick, enabling efficient multi-point affine addition.
- Extract `DotMult` from `PolyMod` into `BarrettReducer` as an internal utility.
- Improve XML documentation for `Reduce`.

#### Point representation (all coordinate systems)
- Introduce `IsInfinity` property and `isOnCurve` internal flag across `ECPoint`, `ECPoint3w`, `ECPoint4w`, `ECPoint5w`, `ECPoint3`, and `ECPoint4`.
- Replace public fields with read‑only properties that return normalized coordinates for the point at infinity, providing safe access without runtime invariant checks.
- Expose internal coordinate fields for direct access from performance‑critical `WeiMath` operations.

#### ECMath batch addition
- Implement `Add(EllipticCurve, ECPoint[], ECPoint[])` for simultaneous affine addition of multiple point pairs, using the batched inversion trick.
- Handle doubling, point‑at‑infinity, and cancellation cases correctly.
- Add robust input validation (null, length mismatch, empty arrays) and descriptive exceptions.
- Fix early return for empty arrays – no longer throws `ArgumentException`.

#### Polynomial fixes & tests
- Fix off‑by‑one in `GetPolyFromRoots` where the first root was skipped.
- Expand Horner evaluation tests (constant, quadratic, high‑degree, outside‑field).
- Add composition identity and Frobenius endomorphism consistency checks.
- Add comprehensive `PolyMod` unit test suite covering constructors, modulus handling, arithmetic, GCD, exponentiation, Brent‑Kung composition, evaluation, equality, and cryptographic group properties.

#### Point test suites
- Add dedicated, exhaustive test classes for every projective point type:  
  `AffinePointTests`, `JacobianPointTests`, `ModJacobianPointTests`, `ChudnovskiPointTests`, `HomProjectivePointTests`, `ExtProjectivePointTests`.
- Cover construction, infinity handling, coordinate access, equality, hashing, collections, and stress scenarios.
- Verify invariants (e.g., `T = XY/Z` for extended Twisted Edwards, `aZ4` rejection, `Z²`/`Z³` consistency).
- Add batch addition edge‑case tests (null args, mismatched lengths, empty arrays, boundary identity/doubling/cancellation).

#### Test naming & readability
- Rename curve operation tests to explicitly reflect what each validates (`_BasePoint_Properties`, `_ConsistentWithAffine`, `_VerifiesGroupLaws`).
- Normalize naming (`Extended_Projective` --> `ExtendedProjective`).
- Remove duplicate `#region` directives.